### PR TITLE
Upload test and reproducibility results

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -52,6 +52,7 @@ jobs:
       # We could have used `verify`, but `clean install` is required while generating the build reproducibility report, which is performed in the next step.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Build
+        id: build
         shell: bash
         run: |
           ./mvnw \
@@ -60,12 +61,34 @@ jobs:
             -DinstallAtEnd=true \
             clean install
 
+      # We upload tests results if the build fails.
+      - name: Upload test results
+        if: failure() && steps.build.conclusion == 'failure'
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32   # 3.1.3
+        with:
+          name: surefire-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
+          path: |
+            **/target/surefire-reports
+            **/target/logs
+
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Verify build reproducibility
+        id: reproducibility
         shell: bash
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -DskipTests=true \
             clean verify artifact:compare
+
+      # We reproducibility results if the build fails.
+      - name: Upload reproducibility results
+        if: failure() && steps.reproducibility.conclusion == 'failure'
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32   # 3.1.3
+        with:
+          name: reproducibility-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
+          path: |
+            **/target/*.buildcompare
+            **/target/*.jar
+            **/target/reference/*.jar

--- a/src/changelog/.10.x.x/add-reports-on-failure.xml
+++ b/src/changelog/.10.x.x/add-reports-on-failure.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="added">
+  <issue id="28" link="https://github.com/apache/logging-parent/issues/28"/>
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Added report uploading in case of test or reproducibility failures.</description>
+</entry>

--- a/src/site/release-notes.adoc
+++ b/src/site/release-notes.adoc
@@ -1,0 +1,40 @@
+////
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+////
+
+////
+    ██     ██  █████  ██████  ███    ██ ██ ███    ██  ██████  ██
+    ██     ██ ██   ██ ██   ██ ████   ██ ██ ████   ██ ██       ██
+    ██  █  ██ ███████ ██████  ██ ██  ██ ██ ██ ██  ██ ██   ███ ██
+    ██ ███ ██ ██   ██ ██   ██ ██  ██ ██ ██ ██  ██ ██ ██    ██
+     ███ ███  ██   ██ ██   ██ ██   ████ ██ ██   ████  ██████  ██
+
+    IF THIS FILE IS CALLED `index.adoc`, IT IS AUTO-GENERATED, DO NOT EDIT IT!
+
+    Release notes `index.adoc` is generated from `src/changelog/.index.adoc.ftl`.
+    Auto-generation happens during `generate-sources` phase of Maven.
+    Hence, you must always
+
+    1. Edit `.index.adoc.ftl`
+    2. Run `./mvnw generate-sources`
+    3. Commit both `.index.adoc.ftl` and the generated `.index.adoc`
+////
+
+[#release-notes]
+== Release Notes
+
+include::release-notes/_10.x.x.adoc[]
+include::release-notes/_10.0.0.adoc[]

--- a/src/site/release-notes/_10.x.x.adoc
+++ b/src/site/release-notes/_10.x.x.adoc
@@ -52,6 +52,7 @@ In particular, we expect the absence of `module-info.java` files to avoid severa
 * Added `asciidoc` and `constants-tmpl-adoc` profiles to generate AsciiDoc-based websites from `src/site`
 * Added support to auto-generate changelog entries for `dependabot` updates
 * Added `bnd-maven-plugin` defaults to auto-generate both OSGi and JPMS descriptors
+* Added report uploading in case of test or reproducibility failures. (https://github.com/apache/logging-parent/issues/28[28])
 * Started publishing https://logging.apache.org/logging-parent/latest[the project website]
 
 ==== Changed


### PR DESCRIPTION
Upload test or reproducibility results as a Github artifact if the associated build step fails.

Closes #28.

This is part of apache/logging-log4j2#1779 and will allow to switch the main repo to use reusable builds.