### PR TITLE
Fix BND module name detection for multi-release jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,9 +657,12 @@
                 # Prevents an execution error in multi-release jars:
                 -fixupmessages: "Classes found in the wrong directory";restrict:=error;is:=warning
 
-                # OSGI modules do not make sense in JPMS
+                # 1. OSGI modules do not make sense in JPMS
+                # 2. BND has a problem detecting the name of multi-release JPMS modules
                 -jpms-module-info-options: org.osgi.core;static=true;transitive=false,\
                   org.osgi.framework;static=true;transitive=false,\
+                  org.apache.logging.log4j;substitute="log4j-api",\
+                  org.apache.logging.log4j.core;substitute="log4j-core",\
                   $[bnd-extra-module-options]
 
                 # Import all packages by default:

--- a/src/changelog/.10.x.x/fix_bnd_required_module_names.xml
+++ b/src/changelog/.10.x.x/fix_bnd_required_module_names.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Fix BND module name detection on multi-release jars.</description>
+</entry>

--- a/src/changelog/.10.x.x/fix_bnd_required_module_names.xml
+++ b/src/changelog/.10.x.x/fix_bnd_required_module_names.xml
@@ -4,5 +4,5 @@
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
        type="fixed">
   <author id="github:ppkarwasz"/>
-  <description format="asciidoc">Fix BND module name detection on multi-release jars.</description>
+  <description format="asciidoc">Fix BND module name detection on multi-release JARs</description>
 </entry>


### PR DESCRIPTION
If a dependency is a multi-release JAR with the module descriptor in `META-INF/versions/9/module-info.class`, BND is not able to detect its module name.

We fix the names of the two multi-release JARs in Apache Logging Services (`log4j-api` and `log4j-core`). The same fix should be applied to all multi-release external dependencies in children POMs.