### PR TITLE
Changes default bundle and module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,8 @@
     <!-- JPMS and OSGi options -->
     <!-- Overrides some options in multi-release JARs -->
     <bnd-multi-release>false</bnd-multi-release>
-    <!-- Module name: defaults to the OSGi symbolic bundle name without hyphens-->
-    <bnd-module-name>$[subst;$[Bundle-SymbolicName];-;.]</bnd-module-name>
+    <!-- Module name: defaults to the OSGi symbolic bundle name -->
+    <bnd-module-name>$[Bundle-SymbolicName]</bnd-module-name>
     <!--
       ~ Allows to change imported package attributes (e.g. add 'resolution:=optional')
       ~ See: https://bnd.bndtools.org/heads/import_package.html
@@ -650,8 +650,9 @@
                 -removeheaders: Bundle-DocURL,Bundle-SCM,Bundle-Developers
 
                 # Create OSGi and JPMS module names based on the `groupId` and `artifactId`.
-                # This agrees with `maven-bundle-plugin`.
-                Bundle-SymbolicName: $[project.groupId].$[subst;$[subst;$[project.artifactId];log4j-];[^A-Za-z0-9];_]
+                # This almost agrees with `maven-bundle-plugin`, but replaces non-alphanumeric characters
+                # with full stops `.`.
+                Bundle-SymbolicName: $[project.groupId].$[subst;$[subst;$[project.artifactId];log4j-];[^A-Za-z0-9];.]
                 -jpms-module-info: $[bnd-module-name];access=0
 
                 # Prevents an execution error in multi-release jars:

--- a/src/changelog/.10.x.x/change_default_module_name.xml
+++ b/src/changelog/.10.x.x/change_default_module_name.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="changed">
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Changes the default OSGi and module name to use full stops `.` instead of non-alphanumeric characters.</description>
+</entry>

--- a/src/changelog/.10.x.x/change_default_module_name.xml
+++ b/src/changelog/.10.x.x/change_default_module_name.xml
@@ -4,5 +4,5 @@
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
        type="changed">
   <author id="github:ppkarwasz"/>
-  <description format="asciidoc">Changes the default OSGi and module name to use full stops `.` instead of non-alphanumeric characters.</description>
+  <description format="asciidoc">Changes the default OSGi and module name to use full stops `.` instead of non-alphanumeric characters</description>
 </entry>


### PR DESCRIPTION
The default bundle name is computed as `groupId`.`artifactId` with non-alphanumeric characters replaces with dots (was `_` underscores).