### PR TITLE
Switch to Palantir Java formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <osgi.annotation.bundle.version>2.0.0</osgi.annotation.bundle.version>
     <osgi.annotation.versioning.version>1.1.2</osgi.annotation.versioning.version>
+    <palantir-java-format.version>2.38.0</palantir-java-format.version>
     <spotbugs-annotations.version>4.8.1</spotbugs-annotations.version>
 
     <!-- plugin versions -->
@@ -719,16 +720,9 @@ import org.apache.commons.codec.digest.*;
  * limitations under the License.
  */</content>
             </licenseHeader>
-            <trimTrailingWhitespace />
-            <endWithNewline />
-            <removeUnusedImports />
-            <indent>
-              <spaces>true</spaces>
-              <spacesPerTab>4</spacesPerTab>
-            </indent>
-            <importOrder>
-              <order>java,javax,jakarta,,\#java,\#javax,\#jakarta,\#</order>
-            </importOrder>
+            <palantirJavaFormat>
+              <version>${palantir-java-format.version}</version>
+            </palantirJavaFormat>
           </java>
           <pom>
             <licenseHeader>

--- a/src/changelog/.10.x.x/add-deterministic-formatter.xml
+++ b/src/changelog/.10.x.x/add-deterministic-formatter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="added">
+  <description format="asciidoc">
+    Add deterministic Palantir Java formatter
+  </description>
+</entry>


### PR DESCRIPTION
Apache Logging Services code requires a deterministic formatter for two reasons:
 * this will eliminate most of the whitespace related differences between `2.x` and `3.x` (`diff -w` does not ignore line breaks),
 * this will allow us to clean up after refactorings performed by tools like Error Prone or OpenRewrite.