### PR TITLE
Allow append to Apache Rat exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -706,7 +706,7 @@ import org.apache.commons.codec.digest.*;
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <consoleOutput>true</consoleOutput>
-          <excludes>
+          <excludes combine.children="append">
             <exclude>.java-version</exclude>
             <exclude>.mvn/jvm.config</exclude>
             <exclude>**/*.txt</exclude>


### PR DESCRIPTION
This patch should allow to append additional exclusions from the child parent