### PR TITLE
Ban wildcard imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
     <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     <log4j-changelog-maven-plugin.version>0.7.0</log4j-changelog-maven-plugin.version>
     <maven-artifact-plugin.version>3.5.0</maven-artifact-plugin.version>
+    <restrict-imports-enforcer-rule.version>2.4.0</restrict-imports-enforcer-rule.version>
     <sign-maven-plugin.version>1.0.1</sign-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.41.1</spotless-maven-plugin.version>
@@ -644,12 +645,22 @@ import org.apache.commons.codec.digest.*;
         </executions>
       </plugin>
 
-      <!-- Ensure that version for each dependency resolved during a build, is equal to or higher than all transitive dependency declarations.
-           A failure here requires adding the dependency to the dependency management. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>de.skuzzle.enforcer</groupId>
+            <artifactId>restrict-imports-enforcer-rule</artifactId>
+            <version>${restrict-imports-enforcer-rule.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
+          <!--
+            ~ Ensure that version for each dependency resolved during a build, is equal to or
+            ~ higher than all transitive dependency declarations.
+            ~ A failure here requires adding the dependency to the dependency management.
+            -->
           <execution>
             <id>enforce-upper-bound-deps</id>
             <goals>
@@ -658,6 +669,24 @@ import org.apache.commons.codec.digest.*;
             <configuration>
               <rules>
                 <requireUpperBoundDeps />
+              </rules>
+            </configuration>
+          </execution>
+          <!--
+            ~ Ensures that no wildcard imports are used.
+            ~ Wildcard imports increase the differences between branches and can not be expanded through simple tools.
+            -->
+          <execution>
+            <id>ban-wildcard-imports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <RestrictImports>
+                  <reason>Expand all wildcard imports</reason>
+                  <bannedImport>**.'*'</bannedImport>
+                </RestrictImports>
               </rules>
             </configuration>
           </execution>

--- a/src/changelog/.10.x.x/ban_wildcard_imports.xml
+++ b/src/changelog/.10.x.x/ban_wildcard_imports.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="added">
+  <issue id="63" link="https://github.com/apache/logging-parent/pull/63"/>
+  <description format="asciidoc">Add enforcer rule to ban wildcard imports.
+All imports must be expanded to provide better comparison of branches.</description>
+</entry>


### PR DESCRIPTION
Add rule to ban wildcard imports. Wildcard imports are often the only difference between branches and they can not easily be expanded by Spotless.

Fixes #63.