### PR TITLE
Add `jspecify` to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
     <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     <log4j-changelog-maven-plugin.version>0.7.0</log4j-changelog-maven-plugin.version>
     <maven-artifact-plugin.version>3.5.0</maven-artifact-plugin.version>
+    <restrict-imports-enforcer-rule.version>2.4.0</restrict-imports-enforcer-rule.version>
     <sign-maven-plugin.version>1.0.1</sign-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.41.1</spotless-maven-plugin.version>
@@ -644,12 +645,22 @@ import org.apache.commons.codec.digest.*;
         </executions>
       </plugin>
 
-      <!-- Ensure that version for each dependency resolved during a build, is equal to or higher than all transitive dependency declarations.
-           A failure here requires adding the dependency to the dependency management. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>de.skuzzle.enforcer</groupId>
+            <artifactId>restrict-imports-enforcer-rule</artifactId>
+            <version>${restrict-imports-enforcer-rule.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
+          <!--
+            ~ Ensure that version for each dependency resolved during a build, is equal to or
+            ~ higher than all transitive dependency declarations.
+            ~ A failure here requires adding the dependency to the dependency management.
+            -->
           <execution>
             <id>enforce-upper-bound-deps</id>
             <goals>
@@ -658,6 +669,24 @@ import org.apache.commons.codec.digest.*;
             <configuration>
               <rules>
                 <requireUpperBoundDeps />
+              </rules>
+            </configuration>
+          </execution>
+          <!--
+            ~ Ensures that no wildcard imports are used.
+            ~ Wildcard imports increase the differences between branches and can not be expanded through simple tools.
+            -->
+          <execution>
+            <id>ban-wildcard-imports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <RestrictImports>
+                  <reason>Expand all wildcard imports</reason>
+                  <bannedImport>**.'*'</bannedImport>
+                </RestrictImports>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
     <org.eclipse.jgit.version>6.8.0.202311291450-r</org.eclipse.jgit.version>
     <!-- These are annotation with a retention of CLASS. They can be freely upgraded. -->
     <bnd.annotation.version>7.0.0</bnd.annotation.version>
+    <jspecify.version>0.3.0</jspecify.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <osgi.annotation.bundle.version>2.0.0</osgi.annotation.bundle.version>
     <osgi.annotation.versioning.version>1.1.2</osgi.annotation.versioning.version>
@@ -323,6 +324,12 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${jspecify.version}</version>
       </dependency>
 
       <dependency>

--- a/src/changelog/.10.x.x/add_jspecify.xml
+++ b/src/changelog/.10.x.x/add_jspecify.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="added">
+  <issue id="88" link="https://github.com/apache/logging-parent/pull/88"/>
+  <description format="asciidoc">Add JSpecify to dependency management.</description>
+</entry>

--- a/src/changelog/.10.x.x/ban_wildcard_imports.xml
+++ b/src/changelog/.10.x.x/ban_wildcard_imports.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="added">
+  <issue id="63" link="https://github.com/apache/logging-parent/pull/63"/>
+  <description format="asciidoc">Add enforcer rule to ban wildcard imports.
+All imports must be expanded to provide better comparison of branches.</description>
+</entry>


### PR DESCRIPTION
This adds [`jspecify`](https://jspecify.dev/) to the dependency management, a common effort of multiple Java tool developers to provide a common set of nullability annotations.

Fixes #88.