### PR TITLE
Disable `-jpms-multi-release` BND option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,6 +514,36 @@
         </executions>
       </plugin>
 
+      <!--
+        ~ Removes a trailing `module-info.class` before each compilation to prevent `javac` failures.
+        ~
+        ~ See https://github.com/copernik-eu/bug-reproducibility/tree/main/javac-module-info-bug
+        -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>delete-module-descriptor</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>${project.build.outputDirectory}</directory>
+                  <includes>
+                    <include>module-info.class</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1026,9 +1026,6 @@ import org.apache.commons.codec.digest.*;
             # Allow each project to override the `Multi-Release` header:
             Multi-Release: $[bnd-multi-release]
 
-            # Add manifests and modules for each multi-release version:
-            -jpms-multi-release: $[bnd-multi-release]
-
             # Adds certain `Implementation-*` and `Specification-*` entries to the generated `MANIFEST.MF`.
             # Using these properties is known to be a bad practice: https://github.com/apache/logging-log4j2/issues/1923#issuecomment-1786818254
             # Users should use `META-INF/maven/<groupId>/<artifactId>/pom.properties` instead.

--- a/pom.xml
+++ b/pom.xml
@@ -1026,6 +1026,13 @@ import org.apache.commons.codec.digest.*;
             # Allow each project to override the `Multi-Release` header:
             Multi-Release: $[bnd-multi-release]
 
+# Skipping to set `-jpms-multi-release` to `bnd-multi-release`.
+# This would generate descriptors in `META-INF/versions/<version>` directories needed for MRJs.
+# Though we decided to skip it due to following reasons:
+# 1. It is only needed by a handful of files in `-java9`-suffixed modules of `logging-log4j2`.
+#    Hence, it is effectively insignificant.
+# 2. `dependency:unpack` and `bnd:bnd-process` executions must be aligned correctly.
+# See this issue for details: https://github.com/apache/logging-parent/issues/93
             # Adds certain `Implementation-*` and `Specification-*` entries to the generated `MANIFEST.MF`.
             # Using these properties is known to be a bad practice: https://github.com/apache/logging-log4j2/issues/1923#issuecomment-1786818254
             # Users should use `META-INF/maven/<groupId>/<artifactId>/pom.properties` instead.

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,7 @@
     <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
     <log4j-changelog-maven-plugin.version>0.7.0</log4j-changelog-maven-plugin.version>
     <maven-artifact-plugin.version>3.5.0</maven-artifact-plugin.version>
+    <restrict-imports-enforcer-rule.version>2.4.0</restrict-imports-enforcer-rule.version>
     <sign-maven-plugin.version>1.0.1</sign-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.41.1</spotless-maven-plugin.version>
@@ -644,12 +645,22 @@ import org.apache.commons.codec.digest.*;
         </executions>
       </plugin>
 
-      <!-- Ensure that version for each dependency resolved during a build, is equal to or higher than all transitive dependency declarations.
-           A failure here requires adding the dependency to the dependency management. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>de.skuzzle.enforcer</groupId>
+            <artifactId>restrict-imports-enforcer-rule</artifactId>
+            <version>${restrict-imports-enforcer-rule.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
+          <!--
+            ~ Ensure that version for each dependency resolved during a build, is equal to or
+            ~ higher than all transitive dependency declarations.
+            ~ A failure here requires adding the dependency to the dependency management.
+            -->
           <execution>
             <id>enforce-upper-bound-deps</id>
             <goals>
@@ -658,6 +669,24 @@ import org.apache.commons.codec.digest.*;
             <configuration>
               <rules>
                 <requireUpperBoundDeps />
+              </rules>
+            </configuration>
+          </execution>
+          <!--
+            ~ Ensures that no wildcard imports are used.
+            ~ Wildcard imports increase the differences between branches and can not be expanded through simple tools.
+            -->
+          <execution>
+            <id>ban-wildcard-imports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <RestrictImports>
+                  <reason>Expand all wildcard imports</reason>
+                  <bannedImport>**.'*'</bannedImport>
+                </RestrictImports>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
     <org.eclipse.jgit.version>6.8.0.202311291450-r</org.eclipse.jgit.version>
     <!-- These are annotation with a retention of CLASS. They can be freely upgraded. -->
     <bnd.annotation.version>7.0.0</bnd.annotation.version>
+    <jspecify.version>0.3.0</jspecify.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <osgi.annotation.bundle.version>2.0.0</osgi.annotation.bundle.version>
     <osgi.annotation.versioning.version>1.1.2</osgi.annotation.versioning.version>
@@ -323,6 +324,12 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${jspecify.version}</version>
       </dependency>
 
       <dependency>

--- a/src/changelog/.10.x.x/add_jspecify.xml
+++ b/src/changelog/.10.x.x/add_jspecify.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="added">
+  <issue id="88" link="https://github.com/apache/logging-parent/pull/88"/>
+  <description format="asciidoc">Add JSpecify to dependency management.</description>
+</entry>

--- a/src/changelog/.10.x.x/ban_wildcard_imports.xml
+++ b/src/changelog/.10.x.x/ban_wildcard_imports.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="added">
+  <issue id="63" link="https://github.com/apache/logging-parent/pull/63"/>
+  <description format="asciidoc">Add enforcer rule to ban wildcard imports.
+All imports must be expanded to provide better comparison of branches.</description>
+</entry>

--- a/src/changelog/.10.x.x/disable_jpms_multi_release.xml
+++ b/src/changelog/.10.x.x/disable_jpms_multi_release.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="changed">
+  <issue id="93" link="https://github.com/apache/logging-parent/pull/93"/>
+  <description format="asciidoc">Disable https://bnd.bndtools.org/instructions/jpms-multi-release.html[`-jpms-multi-release`] BND option.</description>
+</entry>

--- a/src/changelog/.10.x.x/remove-module-info-pre-compile.xml
+++ b/src/changelog/.10.x.x/remove-module-info-pre-compile.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="changed">
+  <issue id="90" link="https://github.com/apache/logging-parent/pull/90"/>
+  <description format="asciidoc">Clean up residual `module-info.class` before compilation.</description>
+</entry>


### PR DESCRIPTION
Due to limitations of BND 6.x and the build process of our multi-release JARs, this option was never effective.

We could reenable it in multi-release JARs that have a difference in package and module dependencies between Java versions.

Closes #93.