### PR TITLE
switched to successor for asciidoc maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
 
         <plugin>
           <groupId>org.asciidoctor</groupId>
-          <artifactId>asciidoctor-maven-plugin</artifactId>
+          <artifactId>asciidoctor-converter-doxia-module</artifactId>
           <version>${asciidoctor-maven-plugin.version}</version>
         </plugin>
 


### PR DESCRIPTION
As described here:
https://docs.asciidoctor.org/maven-tools/latest/site-integration/converter-module-setup-and-configuration/

The asciidoctor-maven-plugin was replaced by the asciidoctor-converter-doxia-module which offers the same functionality. I think we can replace it, but we might have a change on the exclusion in log4j pom. 

So far I don't see any issues, but please let me know if there are some.
