### PR TITLE
Temporary MacOS fixup

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9   # 3.7.0
         with:
-          distribution: temurin
+          distribution: ${{ runner.os == 'macOS' && 'zulu' || 'temurin' }}
           java-version: ${{ inputs.java-version }}
           cache: maven
 


### PR DESCRIPTION
This branch contains temporary fix-ups for MacOS runners and is used by the `logging-log4j2` builds.

We should follow actions/setup-java#625 to see what the definitive solution will be.