### PR TITLE
Selectively disable reproducibility check on build

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -28,6 +28,10 @@ on:
         description: Flag indicating if Maven `site` goal should be run
         default: false
         type: boolean
+      reproducibility-check-enabled:
+        description: Runs a reproducibility check on the build
+        default: true
+        type: boolean
     secrets:
       GE_ACCESS_TOKEN:
         description: Access token to Gradle Enterprise
@@ -106,19 +110,10 @@ jobs:
             --show-version --batch-mode --errors --no-transfer-progress \
             site
 
-      # We upload tests results if the build fails.
-      - name: Upload test results
-        if: failure() && steps.build.conclusion == 'failure'
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808   # 4.3.3
-        with:
-          name: surefire-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
-          path: |
-            **/target/surefire-reports
-            **/target/logs
-
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Verify build reproducibility
+        if: inputs.reproducibility-check-enabled
         id: reproducibility
         shell: bash
         run: |
@@ -129,7 +124,7 @@ jobs:
 
       # Upload reproducibility results if the build fails.
       - name: Upload reproducibility results
-        if: failure() && steps.reproducibility.conclusion == 'failure'
+        if: inputs.reproducibility-check-enabled && failure() && steps.reproducibility.conclusion == 'failure'
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808   # 4.3.3
         with:
           name: reproducibility-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}

--- a/src/changelog/.11.x.x/disable_reproducibility_check.xml
+++ b/src/changelog/.11.x.x/disable_reproducibility_check.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="195" link="https://github.com/apache/logging-parent/pull/195"/>
+  <description format="asciidoc">Add option to disable reproducibility check in reusable builds.</description>
+</entry>


### PR DESCRIPTION
This PR is against the `develocity` branch.

We add a `reproducibility-check-enabled` option to the reusable build that will allow us to turn off the reproducibility check on certain builds.

While the reproducibility check might detect some problems in a release build, IMHO it only increases the build time in most builds.

Reproducibility problems are usually rare and are mostly due to the introduction of additional plugins.
Also note that some kinds of reproducibility problems can only be detected by running the build on a **different** machine. We already encountered problems that only depended on the absolute path of the folder, where the build runs.