### PR TITLE
Improve Develocity build scan support

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -32,8 +32,12 @@ on:
         description: Runs a reproducibility check on the build
         default: true
         type: boolean
+      develocity-enabled:
+        description: Enable Develocity Build Scan publication
+        default: false
+        type: boolean
     secrets:
-      GE_ACCESS_TOKEN:
+      DV_ACCESS_TOKEN:
         description: Access token to Gradle Enterprise
         required: false
 
@@ -64,11 +68,10 @@ jobs:
           cache: maven
 
       - name: Set up Develocity
-        env:
-          HAS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN != null }}
+        if: inputs.develocity-enabled
         shell: bash
         run: |
-          if [ -f .mvn/develocity.xml -a "$HAS_TOKEN" == "true" ]; then
+          if [ -f .mvn/develocity.xml ]; then
             # DEVELOCITY_VERSION=$(./mvnw help:evaluate -q -DforceStdout -Dexpression=develocity-maven-plugin.version)
             # USER_DATA_VERSION=$(./mvnw help:evaluate -q -DforceStdout -Dexpression=common-custom-user-data-maven-extension.version)
             cat >.mvn/extensions.xml <<EOF
@@ -87,13 +90,17 @@ jobs:
           EOF
           fi
 
+      - name: Setup Develocity Build Scan capture
+        if: inputs.develocity-enabled
+        uses: gradle/develocity-actions/maven-setup@v1
+        with:
+          develocity-access-key: ${{ secrets.DV_ACCESS_TOKEN }}
+
       # We could have used `verify`, but `clean install` is required while generating the build reproducibility report, which is performed in the next step.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Build
         id: build
         shell: bash
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Setup Develocity Build Scan capture
         if: inputs.develocity-enabled
-        uses: gradle/develocity-actions/maven-setup@v1
+        uses: gradle/develocity-actions/maven-setup@23b7c25d7e5e4a4dd5bc214d9adb43b837f8917d   # 1
         with:
           develocity-access-key: ${{ secrets.DV_ACCESS_TOKEN }}
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -113,6 +113,7 @@ jobs:
         shell: bash
         run: |
           rm -f .mvn/extensions.xml
+          echo "MAVEN_OPTS=" >> "$GITHUB_ENV"
 
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache

--- a/.github/workflows/codeql-analysis-reusable.yaml
+++ b/.github/workflows/codeql-analysis-reusable.yaml
@@ -30,10 +30,6 @@ on:
         description:
         default: java
         type: string
-    secrets:
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
 
@@ -60,8 +56,6 @@ jobs:
 
       - name: Build with Maven
         shell: bash
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
           --show-version --batch-mode --errors --no-transfer-progress \

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -44,9 +44,6 @@ on:
       SVN_PASSWORD:
         description: Subversion password for uploading the release distribution
         required: true
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
   deploy:
@@ -142,7 +139,6 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           # `SIGN_KEY` is used by `sign-maven-plugin`
           SIGN_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
@@ -175,7 +171,6 @@ jobs:
         env:
           # Making Node.js cache hit visible for debugging purposes
           NODEJS_CACHE_HIT: ${{ steps.nodejs-cache.outputs.cache-hit }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           export TIMESTAMP=$(./mvnw \
             --non-recursive --quiet --batch-mode \
@@ -189,8 +184,6 @@ jobs:
 
       - name: Stage distribution attachments
         shell: bash
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           # Dump deployed artifacts to a local folder
           export ALT_DEPLOYMENT_REPO_FILEPATH="target/alt-deployment-repo"

--- a/.github/workflows/deploy-site-reusable.yaml
+++ b/.github/workflows/deploy-site-reusable.yaml
@@ -44,9 +44,6 @@ on:
       GPG_SECRET_KEY:
         description: GPG secret key for signing commits
         required: true
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
 
@@ -70,8 +67,6 @@ jobs:
       - name: Build the project
         shell: bash
         if: inputs.install-required
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
@@ -104,7 +99,6 @@ jobs:
         env:
           # Making Node.js cache hit visible for debugging purposes
           NODEJS_CACHE_HIT: ${{ steps.nodejs-cache.outputs.cache-hit }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -31,9 +31,6 @@ on:
       NEXUS_PASSWORD:
         description: Nexus snapshot repository password for deploying artifacts
         required: true
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
   deploy:
@@ -69,7 +66,6 @@ jobs:
           # `NEXUS_USERNAME` and `NEXUS_PASSWORD` are used in `~/.m2/settings.xml` created by `setup-java` action
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \

--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -28,9 +28,6 @@ on:
       GPG_SECRET_KEY:
         description: GPG secret key for signing commits
         required: true
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
 

--- a/.github/workflows/scorecards-analysis-reusable.yaml
+++ b/.github/workflows/scorecards-analysis-reusable.yaml
@@ -19,10 +19,6 @@ name: scorecards-analysis
 
 on:
   workflow_call:
-    secrets:
-      GE_ACCESS_TOKEN:
-        description: Access token to Gradle Enterprise
-        required: false
 
 jobs:
 


### PR DESCRIPTION
In order to improve the [Develocity](https://ge.apache.org/) Build Scan support on the Log4j2 project, this PR provides:
- A PR comment and GitHub Workflow [summary](https://github.com/gradle/develocity-actions?tab=readme-ov-file#summary) to ease navigation to the Build Scans
- Develocity [short-lived tokens](https://docs.gradle.com/develocity/api-manual/#short_lived_access_tokens) for authentication
- Build Scan publication only for build-reusable's `Build` step
- A rename from `GE_ACCESS_TOKEN` to `DV_ACCESS_TOKEN`

Note:
A new input `develocity-enabled` is added instead of relying on the presence of the token to enable the Build Scan publication behavior. This allows to publish Build Scans when secrets are not available, following [this approach](https://github.com/gradle/develocity-actions?tab=readme-ov-file#publish-build-scans-for-pull-requests-issued-from-forked-repositories).

Here is the summary that would be generated on the Log4j2's `build` workflow:
![Screenshot 2024-07-17 at 3 41 44 PM](https://github.com/user-attachments/assets/36021989-7e0c-432b-8fbc-b2b105765539)
