### PR TITLE
Add options to enable Develocity

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -28,6 +28,18 @@ on:
         description: Flag indicating if Maven `site` goal should be run
         default: false
         type: boolean
+      reproducibility-check-enabled:
+        description: Runs a reproducibility check on the build
+        default: true
+        type: boolean
+      develocity-enabled:
+        description: Enable Develocity Build Scan publication
+        default: false
+        type: boolean
+    secrets:
+      DV_ACCESS_TOKEN:
+        description: Access token to Gradle Enterprise
+        required: false
 
 jobs:
 
@@ -49,11 +61,40 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
 
       - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018   # 3.7.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018   # 4.2.2
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
           cache: maven
+
+      - name: Set up Develocity
+        if: inputs.develocity-enabled
+        shell: bash
+        run: |
+          if [ -f .mvn/develocity.xml -a "$HAS_TOKEN" == "true" ]; then
+            DEVELOCITY_VERSION=$(./mvnw help:evaluate -q -DforceStdout -Dexpression=develocity-maven-plugin.version)
+            USER_DATA_VERSION=$(./mvnw help:evaluate -q -DforceStdout -Dexpression=common-custom-user-data-maven-extension.version)
+            cat >.mvn/extensions.xml <<EOF
+            <extensions>
+              <extension>
+                <groupId>com.gradle</groupId>
+                <artifactId>develocity-maven-extension</artifactId>
+                <version>$DEVELOCITY_VERSION</version>
+              </extension>
+              <extension>
+                <groupId>com.gradle</groupId>
+                <artifactId>common-custom-user-data-maven-extension</artifactId>
+                <version>$USER_DATA_VERSION</version>
+              </extension>
+            </extensions>
+          EOF
+          fi
+
+      - name: Setup Develocity Build Scan capture
+        if: inputs.develocity-enabled
+        uses: gradle/develocity-actions/maven-setup@23b7c25d7e5e4a4dd5bc214d9adb43b837f8917d   # 1
+        with:
+          develocity-access-key: ${{ secrets.DV_ACCESS_TOKEN }}
 
       # We could have used `verify`, but `clean install` is required while generating the build reproducibility report, which is performed in the next step.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
@@ -66,6 +107,24 @@ jobs:
             -DtrimStackTrace=false \
             -DinstallAtEnd=true \
             clean install
+
+      # We upload tests results.
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029   # 4.3.5
+        with:
+          name: surefire-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
+          path: |
+            **/target/surefire-reports
+            **/target/logs
+
+      - name: Clean up Develocity
+        if: inputs.develocity-enabled
+        shell: bash
+        run: |
+          rm -f .mvn/extensions.xml
+          # Clean up changes introduced by gradle/develocity-actions/maven-setup
+          echo "MAVEN_OPTS=" >> "$GITHUB_ENV"
 
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache
@@ -100,19 +159,10 @@ jobs:
             --show-version --batch-mode --errors --no-transfer-progress \
             site
 
-      # We upload tests results if the build fails.
-      - name: Upload test results
-        if: failure() && steps.build.conclusion == 'failure'
-        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029   # 4.3.5
-        with:
-          name: surefire-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
-          path: |
-            **/target/surefire-reports
-            **/target/logs
-
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Verify build reproducibility
+        if: inputs.reproducibility-check-enabled
         id: reproducibility
         shell: bash
         run: |
@@ -123,7 +173,7 @@ jobs:
 
       # Upload reproducibility results if the build fails.
       - name: Upload reproducibility results
-        if: failure() && steps.reproducibility.conclusion == 'failure'
+        if: inputs.reproducibility-check-enabled && failure() && steps.reproducibility.conclusion == 'failure'
         uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029   # 4.3.5
         with:
           name: reproducibility-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -185,7 +185,6 @@ jobs:
       - name: Stage distribution attachments
         shell: bash
         run: |
-
           # Dump deployed artifacts to a local folder
           export ALT_DEPLOYMENT_REPO_FILEPATH="target/alt-deployment-repo"
           mkdir "$ALT_DEPLOYMENT_REPO_FILEPATH"

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,8 @@
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <cyclonedx-maven-plugin.version>2.8.1</cyclonedx-maven-plugin.version>
     <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
+    <develocity-maven-plugin.version>1.21.5</develocity-maven-plugin.version>
+    <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
     <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
@@ -338,6 +340,20 @@
           <groupId>org.cyclonedx</groupId>
           <artifactId>cyclonedx-maven-plugin</artifactId>
           <version>${cyclonedx-maven-plugin.version}</version>
+        </plugin>
+
+        <!-- Fake entry to be upgraded by Dependabot -->
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>develocity-maven-plugin</artifactId>
+          <version>${develocity-maven-plugin.version}</version>
+        </plugin>
+
+        <!-- Fake entry to be upgraded by Dependabot -->
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>common-custom-user-data-maven-extension</artifactId>
+          <version>${common-custom-user-data-maven-extension.version}</version>
         </plugin>
 
         <plugin>

--- a/src/changelog/.11.x.x/disable_reproducibility_check.xml
+++ b/src/changelog/.11.x.x/disable_reproducibility_check.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="195" link="https://github.com/apache/logging-parent/pull/195"/>
+  <description format="asciidoc">Add option to disable reproducibility check in reusable builds.</description>
+</entry>

--- a/src/changelog/.11.x.x/enable_develocity.xml
+++ b/src/changelog/.11.x.x/enable_develocity.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <description format="asciidoc">Add option to enable Develocity in builds.</description>
+</entry>

--- a/src/site/antora/modules/ROOT/examples/develocity.xml
+++ b/src/site/antora/modules/ROOT/examples/develocity.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<develocity>
+  <projectId>logging-log4j2</projectId>
+  <server>
+    <url>https://ge.apache.org</url>
+  </server>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[env['CI'] != null]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>false</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/src/site/antora/modules/ROOT/pages/features.adoc
+++ b/src/site/antora/modules/ROOT/pages/features.adoc
@@ -54,6 +54,7 @@ The provided reusable GitHub Actions workflows feature the following convenience
 `build-reusable.yaml`::
 * Compiles using the specified Java compiler version
 * Verifies reproducibility
+* Submits build scans to the Develocity server
 
 `deploy-release-reusable.yaml`::
 * Deploys release artifacts
@@ -70,3 +71,59 @@ The provided reusable GitHub Actions workflows feature the following convenience
 
 `merge-dependabot-reusable.yaml`::
 * Merges `dependabot` PRs changelog entries
+
+[#develocity-configuration]
+=== Develocity configuration
+
+https://gradle.com/develocity/[Gradle Develocity] is a service that provides statistics and other improvements to the development experience.
+Due to an
+https://gradle.com/blog/apache-software-foundation-standardizes-on-gradle-develocity-to-improve-developer-productivity-experience/[agreement between the ASF and Gradle],
+it is available for all ASF projects as INFRA hosted https://ge.apache.org/[`ge.apache.org`] service.
+
+To submit build scans to the `ge.apache.org` server you need to:
+
+. Add a `.mvn/develocity.xml` configuration file to the repository.
+See
+https://docs.gradle.com/develocity/maven-extension/current/[Develocity Maven Extension User Manual]
+for detailed configuration options.
++
+You can use the following example as template:
++
+[source,xml]
+----
+include::example$develocity.xml[lines=1;18..-1]
+----
++
+[NOTE]
+====
+Do **not** add any `.mvn/extensions.xml` file to the repository.
+The file will be created by the `reusable-build` workflow.
+====
+
+. Modify the build workflow that should publish build scans:
++
+--
+* Pass the `secrets.GE_ACCESS_TOKEN`, which is defined in all ASF repos as `DV_ACCESS_TOKEN` secret of the workflow.
+
+* Set the `develocity-enabled` parameter to `true`.
+--
++
+For example, you can use the snippet below:
++
+[source,yaml,subs="+attributes"]
+----
+build:
+  uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/{project-version}
+  secrets:
+    DV_ACCESS_TOKEN: ${{ ! startsWith(github.refname, 'release/') && secrets.GE_ACCESS_TOKEN }}
+  with:
+    develocity-enabled: ${{ ! startsWith(github.refname, 'release/') }}
+----
++
+[IMPORTANT]
+====
+The Maven Develocity Extension is a **closed source** extension, which requires a commercial
+https://gradle.com/[Gradle Inc]
+license to work.
+To guarantee the reproducibility of our builds and the security of our software suplly chain, please disable the extension in our **release** builds.
+====


### PR DESCRIPTION
This PR moves the changes from the experimental `develocity` branch to the `main` branch.

It features two main changes:

1. A new `reproducibility-check-enabled` option for the reusable builds. This option allow to disable reproducibility checks in some workflows.
2. A new `develocity-enabled` option for the reusable builds. This option allows to publish the result of the build to the https://ge.apache.org server.