### PR TITLE
Allow GitHub to mark a PR as `merged` not `closed`

### DIFF
--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -122,6 +122,8 @@ jobs:
           git config user.name "ASF Logging Services RM"
           git config user.email private@logging.apache.org
           git commit -S -a -m "Update \`$DEPENDENCY_NAME\` to version \`$DEPENDENCY_VERSION\` (#$PR_ID)"
-          git push origin
-          # Pushing the same commit to the Dependebot branch closes the PR
+          # Pushing the same commit to the Dependabot and main branch closes the PR
           git push -f origin "HEAD:$PR_BRANCH"
+          # Allow for GitHub to realize that the PR branch changed
+          sleep 5
+          git push origin

--- a/src/changelog/.11.x.x/pr-merge-race-condition.xml
+++ b/src/changelog/.11.x.x/pr-merge-race-condition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <description format="asciidoc">Fix race condition, which marks merged Dependabot PRs as closed.</description>
+</entry>


### PR DESCRIPTION
We reverse the order of updates to the PR branch and main branch and allow GitHub time to realize that both branches have the same ref.

This should always mark the PR as "merged", while currently it often is marked as "closed".