### PR TITLE
Adds `maven-args` option to workflows

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -20,26 +20,33 @@ name: build-reusable
 on:
   workflow_call:
     inputs:
-      java-version:
-        description: The Java compiler version
-        default: 17
-        type: string
-      site-enabled:
-        description: Flag indicating if Maven `site` goal should be run
-        default: false
-        type: boolean
-      reproducibility-check-enabled:
-        description: Runs a reproducibility check on the build
-        default: true
-        type: boolean
       develocity-enabled:
         description: Enable Develocity Build Scan publication
         default: false
         type: boolean
+      java-version:
+        description: The Java compiler version
+        default: 17
+        type: string
+      maven-args:
+        description: Additional Maven arguments
+        type: string
+      reproducibility-check-enabled:
+        description: Runs a reproducibility check on the build
+        default: true
+        type: boolean
+      site-enabled:
+        description: Flag indicating if Maven `site` goal should be run
+        default: false
+        type: boolean
+
     secrets:
       DV_ACCESS_TOKEN:
         description: Access token to Gradle Enterprise
         required: false
+
+env:
+  MAVEN_ARGS: ${{ inputs.maven-args }}
 
 jobs:
 
@@ -141,7 +148,7 @@ jobs:
           # For that, we need to configure `dependabot` to update hundreds of dependencies listed in `package-lock.json`.
           # That translates to a never ending rain of `dependabot` PRs.
           # I doubt if the wasted CPU cycles worth the gain.
-          key: ${{ runner.os }}-nodejs-cache-${{ hashFiles('node', 'node_modules') }}
+          key: "${{ runner.os }}-nodejs-cache-${{ hashFiles('node', 'node_modules') }}"
           # `actions/cache` doesn't recommend caching `node_modules`.
           # Though none of its recipes fit our bill, since we install Node.js using `frontend-maven-plugin`.
           # See https://github.com/actions/cache/blob/main/examples.md#node---npm

--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -24,10 +24,16 @@ on:
         description: The Java compiler version
         default: 17
         type: string
+      maven-args:
+        description: Additional Maven arguments
+        type: string
     secrets:
       GPG_SECRET_KEY:
         description: GPG secret key for signing commits
         required: true
+
+env:
+  MAVEN_ARGS: ${{ inputs.maven-args }}
 
 jobs:
 
@@ -80,6 +86,8 @@ jobs:
 
       - name: Find the release version major
         shell: bash
+        env:
+          MAVEN_ARGS: ${{ inputs.maven-args }}
         run: |
           RELEASE_VERSION_MAJOR=$(./mvnw \
             --non-recursive --quiet --batch-mode \

--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -86,8 +86,6 @@ jobs:
 
       - name: Find the release version major
         shell: bash
-        env:
-          MAVEN_ARGS: ${{ inputs.maven-args }}
         run: |
           RELEASE_VERSION_MAJOR=$(./mvnw \
             --non-recursive --quiet --batch-mode \

--- a/src/changelog/.11.x.x/maven-args.xml
+++ b/src/changelog/.11.x.x/maven-args.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="266" link="https://github.com/apache/logging-parent/pull/266"/>
+  <description format="asciidoc">Add `maven-args` input to `build-reusable` and `merge-dependabot-reusable`.</description>
+</entry>


### PR DESCRIPTION
We add `maven-args` option to the:

* `build-reusable.yaml` workflow.
* `merge-dependabot-reusable.yaml` workflow.

This parameter sets the
[`MAVEN_ARGS`](https://maven.apache.org/configure.html#maven_args-environment-variable) environment variable that can be used to pass additional options (e.g. `-Prelease`, `-Dslf4j.version=...`) to the Maven runs.

Note that we don't add an equivalent option for
[`MAVEN_OPTS`](https://maven.apache.org/configure.html#maven_opts-environment-variable), since the JVM parameters for Maven can be stored in a `.mvn/jvm.config` file.