### PR TITLE
Add verification step to release instructions

### DIFF
--- a/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
+++ b/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
@@ -91,7 +91,22 @@ You can iterate on the `release/7.8.0` branch to perfect it.
 .. {site-url-staging}-7.8.0[The release staging website] is deployed using the freshly populated `release/7.8.0-site-stg-out` branch
 
 +
-If not, commit necessary fixes, push, and repeat.
+If not, commit the necessary fixes, push, and repeat.
+
+[#verify-release]
+== Verify the release
+
+Once the release is staged, the Release Manager should:
+
+. Close the _Staging Repository_ in https://repository.apache.org/[repository.apache.org] using a message that uniquely identifies the release, for example `awesome-project version 7.8.0 RC1`.
+. Follow the xref:release-review-instructions.adoc[] to verify the integrity of the release.
+. Some projects have additional integration tests that need to run on the release candidate artifacts:
+
+`logging-log4j2`::
++
+Run the
+https://github.com/apache/logging-log4j-samples/actions/workflows/integration-test.yaml[integration-test.yaml]
+workflow using the appropriate version number and URL of the _Staging Repository_ as parameters.
 
 [#vote-release]
 == Vote the release

--- a/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
+++ b/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
@@ -98,7 +98,6 @@ If not, commit the necessary fixes, push, and repeat.
 
 Once the release is staged, the Release Manager should:
 
-. Close the _Staging Repository_ in https://repository.apache.org/[repository.apache.org] using a message that uniquely identifies the release, for example `awesome-project version 7.8.0 RC1`.
 . Follow the xref:release-review-instructions.adoc[] to verify the integrity of the release.
 . Some projects have additional integration tests that need to run on the release candidate artifacts:
 


### PR DESCRIPTION
Although it might be obvious that Release Managers should abide to the same rules as the other voters, this should be stated explicitly. This PR:

- Explicitly asks Release Managers to perform a verification step, **before** sending the release vote.
- Adds per-project CI workflows that need to run on the generated artifacts. For Log4j there is an `integration-test.yaml` in samples that verifies the compatibility of the release with JLink, GraalVM and Android.