### PR TITLE
Export deployment data to calling workflow

### DIFF
--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -28,6 +28,13 @@ on:
         description: Identifier used in the distribution artifact and Subversion repository folder filenames (e.g., `logging-parent`)
         required: true
         type: string
+    outputs:
+      project-version:
+        description: The version of the project
+        value: ${{ jobs.deploy.outputs.project-version }}
+      project-repository-url:
+        description: The URL of the Nexus repository used
+        value: ${{ jobs.deploy.outputs.project-repository-url }}
     secrets:
       GPG_SECRET_KEY:
         description: GPG secret key for signing artifacts
@@ -48,6 +55,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.project-version }}
+      project-repository-url: ${{ steps.nexus.outputs.project-repository-url }}
     steps:
 
       - name: Checkout repository
@@ -72,6 +82,7 @@ jobs:
           git config user.email private@logging.apache.org
 
       - name: Export version
+        id: version
         shell: bash
         env:
           GIT_BRANCH_NAME: ${{ github.ref_name }}
@@ -82,6 +93,8 @@ jobs:
           }
           export PROJECT_VERSION=$(echo "$GIT_BRANCH_NAME" | sed 's/^release\///')
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          # Export version to calling workflow
+          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set the Maven `revision` property
         shell: bash
@@ -132,6 +145,7 @@ jobs:
           fi
 
       - name: Upload to Nexus
+        id: nexus
         shell: bash
         env:
           # `NEXUS_USERNAME` and `NEXUS_PASSWORD` are used in `~/.m2/settings.xml` created by `setup-java` action
@@ -145,6 +159,8 @@ jobs:
             -P deploy,release
           export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
           echo "NEXUS_URL=$NEXUS_URL" >> $GITHUB_ENV
+          # Export repository URL to calling workflow
+          echo "project-repository-url=$NEXUS_URL" >> $GITHUB_OUTPUT
 
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache
@@ -158,7 +174,7 @@ jobs:
           # For that, we need to configure `dependabot` to update hundreds of dependencies listed in `package-lock.json`.
           # That translates to a never ending rain of `dependabot` PRs.
           # I doubt if the wasted CPU cycles worth the gain.
-          key: ${{ runner.os }}-nodejs-cache-${{ hashFiles('node', 'node_modules') }}
+          key: "${{ runner.os }}-nodejs-cache-${{ hashFiles('node', 'node_modules') }}"
           # `actions/cache` doesn't recommend caching `node_modules`.
           # Though none of its recipes fit our bill, since we install Node.js using `frontend-maven-plugin`.
           # See https://github.com/actions/cache/blob/main/examples.md#node---npm

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -29,12 +29,9 @@ on:
         required: true
         type: string
     outputs:
-      project-version:
-        description: The version of the project
-        value: ${{ jobs.deploy.outputs.project-version }}
-      project-repository-url:
+      nexus-url:
         description: The URL of the Nexus repository used
-        value: ${{ jobs.deploy.outputs.project-repository-url }}
+        value: ${{ jobs.deploy.outputs.nexus-url }}
     secrets:
       GPG_SECRET_KEY:
         description: GPG secret key for signing artifacts
@@ -56,8 +53,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
-      project-version: ${{ steps.version.outputs.project-version }}
-      project-repository-url: ${{ steps.nexus.outputs.project-repository-url }}
+      nexus-url: ${{ steps.nexus.outputs.nexus-url }}
     steps:
 
       - name: Checkout repository
@@ -82,7 +78,6 @@ jobs:
           git config user.email private@logging.apache.org
 
       - name: Export version
-        id: version
         shell: bash
         env:
           GIT_BRANCH_NAME: ${{ github.ref_name }}
@@ -93,8 +88,6 @@ jobs:
           }
           export PROJECT_VERSION=$(echo "$GIT_BRANCH_NAME" | sed 's/^release\///')
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-          # Export version to calling workflow
-          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set the Maven `revision` property
         shell: bash
@@ -160,7 +153,7 @@ jobs:
           export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
           echo "NEXUS_URL=$NEXUS_URL" >> $GITHUB_ENV
           # Export repository URL to calling workflow
-          echo "project-repository-url=$NEXUS_URL" >> $GITHUB_OUTPUT
+          echo "nexus-url=$NEXUS_URL" >> $GITHUB_OUTPUT
 
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -29,6 +29,9 @@ on:
         required: true
         type: string
     outputs:
+      project-version:
+        description: The version of the project
+        value: ${{ jobs.deploy.outputs.project-version }}
       nexus-url:
         description: The URL of the Nexus repository used
         value: ${{ jobs.deploy.outputs.nexus-url }}
@@ -53,6 +56,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
+      project-version: ${{ steps.version.outputs.project-version }}
       nexus-url: ${{ steps.nexus.outputs.nexus-url }}
     steps:
 
@@ -78,6 +82,7 @@ jobs:
           git config user.email private@logging.apache.org
 
       - name: Export version
+        id: version
         shell: bash
         env:
           GIT_BRANCH_NAME: ${{ github.ref_name }}
@@ -88,6 +93,8 @@ jobs:
           }
           export PROJECT_VERSION=$(echo "$GIT_BRANCH_NAME" | sed 's/^release\///')
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          # Export version to calling workflow
+          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set the Maven `revision` property
         shell: bash

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -83,4 +83,3 @@ jobs:
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -P deploy
-          export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -28,9 +28,10 @@ on:
       project-version:
         description: The version of the project
         value: ${{ jobs.deploy.outputs.project-version }}
+      # Constant output for similarity with `deploy-release-reusable`
       nexus-url:
         description: The URL of the Nexus repository used
-        value: ${{ jobs.deploy.outputs.nexus-url }}
+        value: https://repository.apache.org/content/repositories/snapshots
     secrets:
       NEXUS_USERNAME:
         description: Nexus snapshot repository username for deploying artifacts
@@ -44,7 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       project-version: ${{ steps.version.outputs.project-version }}
-      nexus-url: ${{ steps.nexus.outputs.nexus-url }}
     steps:
 
       - name: Checkout repository
@@ -74,7 +74,6 @@ jobs:
           echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload to Nexus
-        id: nexus
         shell: bash
         env:
           # `NEXUS_USERNAME` and `NEXUS_PASSWORD` are used in `~/.m2/settings.xml` created by `setup-java` action
@@ -85,5 +84,3 @@ jobs:
             --show-version --batch-mode --errors --no-transfer-progress \
             -P deploy
           export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
-          # Export repository URL to calling workflow
-          echo "nexus-url=$NEXUS_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -25,12 +25,9 @@ on:
         default: 17
         type: string
     outputs:
-      project-version:
-        description: The version of the project
-        value: ${{ jobs.deploy.outputs.project-version }}
-      project-repository-url:
+      nexus-url:
         description: The URL of the Nexus repository used
-        value: ${{ jobs.deploy.outputs.project-repository-url }}
+        value: ${{ jobs.deploy.outputs.nexus-url }}
     secrets:
       NEXUS_USERNAME:
         description: Nexus snapshot repository username for deploying artifacts
@@ -43,8 +40,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
-      project-version: ${{ steps.version.outputs.project-version }}
-      project-repository-url: ${{ steps.nexus.outputs.project-repository-url }}
+      nexus-url: ${{ steps.nexus.outputs.nexus-url }}
     steps:
 
       - name: Checkout repository
@@ -61,7 +57,6 @@ jobs:
           server-password: NEXUS_PASSWORD
 
       - name: Export version
-        id: version
         shell: bash
         run: |
           export PROJECT_VERSION=$(./mvnw \
@@ -70,8 +65,6 @@ jobs:
             help:evaluate \
             | tail -n 1)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-          # Export version to calling workflow
-          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload to Nexus
         id: nexus
@@ -86,4 +79,4 @@ jobs:
             -P deploy
           export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
           # Export repository URL to calling workflow
-          echo "project-repository-url=$NEXUS_URL" >> $GITHUB_OUTPUT
+          echo "nexus-url=$NEXUS_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -25,6 +25,9 @@ on:
         default: 17
         type: string
     outputs:
+      project-version:
+        description: The version of the project
+        value: ${{ jobs.deploy.outputs.project-version }}
       nexus-url:
         description: The URL of the Nexus repository used
         value: ${{ jobs.deploy.outputs.nexus-url }}
@@ -40,6 +43,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
+      project-version: ${{ steps.version.outputs.project-version }}
       nexus-url: ${{ steps.nexus.outputs.nexus-url }}
     steps:
 
@@ -57,6 +61,7 @@ jobs:
           server-password: NEXUS_PASSWORD
 
       - name: Export version
+        id: version
         shell: bash
         run: |
           export PROJECT_VERSION=$(./mvnw \
@@ -65,6 +70,8 @@ jobs:
             help:evaluate \
             | tail -n 1)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          # Export version to calling workflow
+          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload to Nexus
         id: nexus

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -24,6 +24,13 @@ on:
         description: The Java compiler version
         default: 17
         type: string
+    outputs:
+      project-version:
+        description: The version of the project
+        value: ${{ jobs.deploy.outputs.project-version }}
+      project-repository-url:
+        description: The URL of the Nexus repository used
+        value: ${{ jobs.deploy.outputs.project-repository-url }}
     secrets:
       NEXUS_USERNAME:
         description: Nexus snapshot repository username for deploying artifacts
@@ -35,6 +42,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.project-version }}
+      project-repository-url: ${{ steps.nexus.outputs.project-repository-url }}
     steps:
 
       - name: Checkout repository
@@ -51,6 +61,7 @@ jobs:
           server-password: NEXUS_PASSWORD
 
       - name: Export version
+        id: version
         shell: bash
         run: |
           export PROJECT_VERSION=$(./mvnw \
@@ -59,8 +70,11 @@ jobs:
             help:evaluate \
             | tail -n 1)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          # Export version to calling workflow
+          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload to Nexus
+        id: nexus
         shell: bash
         env:
           # `NEXUS_USERNAME` and `NEXUS_PASSWORD` are used in `~/.m2/settings.xml` created by `setup-java` action
@@ -70,3 +84,6 @@ jobs:
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -P deploy
+          export NEXUS_URL=$(awk '/^(stagingRepository.url)/ { gsub(/(^.+=|\\)/, ""); print $1 }' target/nexus-staging/staging/*.properties)
+          # Export repository URL to calling workflow
+          echo "project-repository-url=$NEXUS_URL" >> $GITHUB_OUTPUT

--- a/src/changelog/.11.x.x/export_deployment_data.xml
+++ b/src/changelog/.11.x.x/export_deployment_data.xml
@@ -5,6 +5,6 @@
        type="changed">
   <issue id="246" link="https://github.com/apache/logging-parent/pull/246"/>
   <description format="asciidoc">
-    The `deploy-*-reusable` workflows export the URL of the Nexus repository as `nexus-url` workflow output.
+    The `deploy-*-reusable` workflows export the URL of the Nexus repository as `nexus-url` workflow output and the project version as `project-version`.
   </description>
 </entry>

--- a/src/changelog/.11.x.x/export_deployment_data.xml
+++ b/src/changelog/.11.x.x/export_deployment_data.xml
@@ -5,6 +5,6 @@
        type="changed">
   <issue id="246" link="https://github.com/apache/logging-parent/pull/246"/>
   <description format="asciidoc">
-    The `deploy-*-reusable` workflows export the project version and URL of the staging repository as `project-version` and `project-repository-url` workflow outputs.
+    The `deploy-*-reusable` workflows export the URL of the Nexus repository as `nexus-url` workflow output.
   </description>
 </entry>

--- a/src/changelog/.11.x.x/export_deployment_data.xml
+++ b/src/changelog/.11.x.x/export_deployment_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="246" link="https://github.com/apache/logging-parent/pull/246"/>
+  <description format="asciidoc">
+    The `deploy-*-reusable` workflows export the project version and URL of the staging repository as `project-version` and `project-repository-url` workflow outputs.
+  </description>
+</entry>


### PR DESCRIPTION
This adds two outputs to both the `deploy-release-reusable` and `deploy-snapshot-reusable` workflows:

- `project-version`: contains the version of the deployed project.
- `nexus-url`: contains the URL of the Nexus repository, where the artifacts were deployed.

This PR is based on the GitHub [Using outputs from a reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow) documentation.

[It also fixes a small YAML syntax error, ignored by GitHub, but reported by IDEA]