### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <spotless-maven-plugin.version>2.44.1</spotless-maven-plugin.version>
     <xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
     <!-- Due to a missing `maven-metadata.xml`, Dependabot does not update this automatically -->
-    <develocity-maven-plugin.version>1.23</develocity-maven-plugin.version>
+    <develocity-maven-plugin.version>1.22.2</develocity-maven-plugin.version>
     <develocity-user-data-extension.version>2.0.1</develocity-user-data-extension.version>
 
     <!-- plugin dependencies versions -->

--- a/src/changelog/.11.x.x/move_to_develocity_apache_org.xml
+++ b/src/changelog/.11.x.x/move_to_develocity_apache_org.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="313" link="https://github.com/apache/logging-parent/pull/313"/>
+  <description format="asciidoc">
+    Move from `ge.apache.org` to new `develocity.apache.org` server.
+  </description>
+</entry>

--- a/src/site/antora/modules/ROOT/examples/develocity.xml
+++ b/src/site/antora/modules/ROOT/examples/develocity.xml
@@ -18,7 +18,7 @@
 <develocity>
   <projectId>logging-log4j2</projectId>
   <server>
-    <url>https://ge.apache.org</url>
+    <url>https://develocity.apache.org</url>
   </server>
   <buildScan>
     <obfuscation>

--- a/src/site/antora/modules/ROOT/pages/features.adoc
+++ b/src/site/antora/modules/ROOT/pages/features.adoc
@@ -89,9 +89,9 @@ See following guides for projects employing {project-name} to cut releases:
 https://gradle.com/develocity/[Gradle Develocity] is a service that provides statistics and other improvements to the development experience.
 Due to an
 https://gradle.com/blog/apache-software-foundation-standardizes-on-gradle-develocity-to-improve-developer-productivity-experience/[agreement between the ASF and Gradle],
-it is available for all ASF projects as INFRA hosted https://ge.apache.org/[`ge.apache.org`] service.
+it is available for all ASF projects as INFRA hosted https://develocity.apache.org/[`develocity.apache.org`] service.
 
-.Click for instructions to submit build scans to the `ge.apache.org` server
+.Click for instructions to submit build scans to the `develocity.apache.org` server
 [%collapsible]
 ====
 . Add a `.mvn/develocity.xml` configuration file to the repository.

--- a/src/site/antora/modules/ROOT/pages/features.adoc
+++ b/src/site/antora/modules/ROOT/pages/features.adoc
@@ -115,7 +115,7 @@ The file will be created by the `reusable-build` workflow.
 . Modify the build workflow that should publish build scans:
 +
 --
-* Pass the `secrets.GE_ACCESS_TOKEN`, which is defined in all ASF repos as `DV_ACCESS_TOKEN` secret of the workflow.
+* Pass the `secrets.DEVELOCITY_ACCESS_KEY`, which is defined in all ASF repos as `DV_ACCESS_TOKEN` secret of the workflow.
 
 * Set the `develocity-enabled` parameter to `true`.
 --
@@ -127,7 +127,7 @@ For example, you can use the snippet below:
 build:
   uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/{project-version}
   secrets:
-    DV_ACCESS_TOKEN: ${{ ! startsWith(github.refname, 'release/') && secrets.GE_ACCESS_TOKEN }}
+    DV_ACCESS_TOKEN: ${{ ! startsWith(github.refname, 'release/') && secrets.DEVELOCITY_ACCESS_KEY }}
   with:
     develocity-enabled: ${{ ! startsWith(github.refname, 'release/') }}
 ----


### PR DESCRIPTION
This PR migrates the Log4j project to publish Build Scans to the the new Develocity instance at develocity.apache.org.
