### PR TITLE
Improve resilience to script injection

### DIFF
--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -55,8 +55,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      PROJECT_ID: ${{ inputs.project-id }}
     outputs:
       project-version: ${{ steps.version.outputs.project-version }}
       nexus-url: ${{ steps.nexus.outputs.nexus-url }}
@@ -226,6 +224,8 @@ jobs:
 
       - name: Create the distribution
         shell: bash
+        env:
+          PROJECT_ID: ${{ inputs.project-id }}
         run: |
 
           # Generate the distribution (i.e., `src.zip` and optional `bin.zip`)
@@ -265,6 +265,7 @@ jobs:
       - name: Upload to Subversion
         shell: bash
         env:
+          PROJECT_ID: ${{ inputs.project-id }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -55,6 +55,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ inputs.project-id }}
     outputs:
       project-version: ${{ steps.version.outputs.project-version }}
       nexus-url: ${{ steps.nexus.outputs.nexus-url }}
@@ -235,7 +237,7 @@ jobs:
             -DattachmentCount="$DIST_ATTACHMENT_COUNT"
 
           # Rename distribution files
-          export DIST_FILENAME_PREFIX="apache-${{ inputs.project-id }}"
+          export DIST_FILENAME_PREFIX="apache-${PROJECT_ID}"
           export DIST_FILENAME_VERSIONED_PREFIX="${DIST_FILENAME_PREFIX}-${PROJECT_VERSION}"
           export DIST_FILEPATH_PREFIX="/tmp/${DIST_FILENAME_VERSIONED_PREFIX}"
           export DIST_FILEPATH_SRC="${DIST_FILEPATH_PREFIX}-src.zip"
@@ -263,7 +265,6 @@ jobs:
       - name: Upload to Subversion
         shell: bash
         env:
-          PROJECT_ID: ${{ inputs.project-id }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -73,8 +73,10 @@ jobs:
     steps:
       - name: Export version
         id: export-version
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          version=$(echo "${{ github.ref_name }}" | sed 's/^release\///')
+          version=$(echo "$REF_NAME" | sed 's/^release\///' | tr -d '\r\n')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
   deploy-site-rel:

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -37,6 +37,7 @@ on:
 
 env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
+  NEXUS_URL: ${{ inputs.nexus-url }}
 
 jobs:
 
@@ -70,7 +71,7 @@ jobs:
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -DskipTests=true \
-            -Dreference.repo=${{ inputs.nexus-url }} \
+            -Dreference.repo="${NEXUS_URL}" \
             clean verify artifact:compare
 
       # Upload reproducibility results if the build fails.

--- a/src/changelog/.11.x.x/update_dependabot_fetch_metadata.xml
+++ b/src/changelog/.11.x.x/update_dependabot_fetch_metadata.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="https://logging.apache.org/xml/ns"
-       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="updated">
-  <issue id="322" link="https://github.com/apache/logging-parent/pull/322"/>
-  <description format="asciidoc">Update `dependabot/fetch-metadata` to version `2.3.0`</description>
-</entry>


### PR DESCRIPTION
This change removes all direct usages of GitHub expressions to prevent potential script injections.

**Note**: The GitHub expressions modified in this PR only come from **trusted** sources, so these problems are not exploitable. We wish, however, to prevent possible errors in the future.