### PR TITLE
Add all active team members as developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,70 @@
   <developers>
 
     <developer>
+      <id>pkarwasz</id>
+      <name>Piotr P. Karwasz</name>
+      <email>pkarwasz@apache.org</email>
+      <url>https://github.com/sponsors/ppkarwasz</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Chair</role>
+      </roles>
+      <timezone>Europe/Warsaw</timezone>
+    </developer>
+
+    <developer>
+      <id>ckozak</id>
+      <name>Carter Kozak</name>
+      <email>ckozak@apache.org</email>
+      <url>https://github.com/sponsors/carterkozak</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>America/New York</timezone>
+    </developer>
+
+    <developer>
+      <id>grobmeier</id>
+      <name>Christian Grobmeier</name>
+      <email>grobmeier@apache.org</email>
+      <url>https://github.com/sponsors/grobmeier</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+
+    <developer>
+      <id>davydm</id>
+      <name>Davyd McColl</name>
+      <email>davydm@apache.org</email>
+      <url>https://github.com/sponsors/fluffynuts</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>Africa/Johannesburg</timezone>
+    </developer>
+
+    <developer>
+      <id>dpsenner</id>
+      <name>Dominik Psenner</name>
+      <email>dpsenner@apache.org</email>
+      <url>https://github.com/sponsors/dpsenner</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+    </developer>
+
+    <developer>
       <id>ggregory</id>
       <name>Gary Gregory</name>
       <email>ggregory@apache.org</email>
-      <url>https://www.garygregory.com</url>
+      <url>https://github.com/sponsors/garydgregory</url>
       <organization>The Apache Software Foundation</organization>
-      <organizationUrl>https://www.apache.org/</organizationUrl>
       <roles>
         <role>PMC Member</role>
       </roles>
@@ -59,9 +117,11 @@
     </developer>
 
     <developer>
-      <id>grobmeier</id>
-      <name>Christian Grobmeier</name>
-      <email>grobmeier@apache.org</email>
+      <id>freeandnil</id>
+      <name>Jan Friedrich</name>
+      <email>freeandnil@apache.org</email>
+      <url>https://github.com/sponsors/FreeAndNil</url>
+      <organization>The Apache Software Foundation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>
@@ -72,7 +132,8 @@
       <id>mattsicker</id>
       <name>Matt Sicker</name>
       <email>mattsicker@apache.org</email>
-      <organization>Apple</organization>
+      <url>https://github.com/sponsors/jvz</url>
+      <organization>The Apache Software Foundation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>
@@ -80,25 +141,133 @@
     </developer>
 
     <developer>
-      <id>pkarwasz</id>
-      <name>Piotr P. Karwasz</name>
-      <email>pkarwasz@apache.org</email>
+      <id>rgoers</id>
+      <name>Ralph Goers</name>
+      <email>rgoers@apache.org</email>
+      <url>https://github.com/sponsors/rgoers</url>
+      <organization>The Apache Software Foundation</organization>
       <roles>
         <role>PMC Member</role>
       </roles>
-      <timezone>Europe/Warsaw</timezone>
+      <timezone>America/Phoenix</timezone>
+    </developer>
+
+    <developer>
+      <id>rpopma</id>
+      <name>Remko Popma</name>
+      <email>rpopma@apache.org</email>
+      <url>https://github.com/sponsors/remkop</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>Asia/Tokyo</timezone>
+    </developer>
+
+    <developer>
+      <id>rmiddleton</id>
+      <name>Robert Middleton</name>
+      <email>rmiddleton@apache.org</email>
+      <url>https://github.com/sponsors/rm5248</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <id>rgrabowski</id>
+      <name>Ron Grabowski</name>
+      <email>rgrabowski@apache.org</email>
+      <url>https://github.com/sponsors/ronosaurus</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <id>sdeboy</id>
+      <name>Scott Deboy</name>
+      <email>sdeboy@apache.org</email>
+      <url>https://github.com/sponsors/scottdeboy</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <id>swebb2066</id>
+      <name>Stephen Webb</name>
+      <email>swebb2066@apache.org</email>
+      <url>https://github.com/sponsors/swebb2066</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>Australia/Sydney</timezone>
     </developer>
 
     <developer>
       <id>vy</id>
       <name>Volkan Yazıcı</name>
       <email>vy@apache.org</email>
+      <url>https://github.com/sponsors/vy</url>
+      <organization>The Apache Software Foundation</organization>
       <roles>
-        <role>PMC Chair</role>
+        <role>PMC Member</role>
       </roles>
       <timezone>Europe/Amsterdam</timezone>
     </developer>
 
+    <developer>
+      <id>jaykatariya</id>
+      <name>Jay Katariya</name>
+      <email>jaykatariya@apache.org</email>
+      <url>https://github.com/sponsors/jaykataria1111</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>America/Los_Angeles</timezone>
+    </developer>
+
+    <developer>
+      <id>jwthomas</id>
+      <name>Jeff Thomas</name>
+      <email>jwthomas@apache.org</email>
+      <url>https://github.com/sponsors/JWT007</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+
+    <developer>
+      <id>rgupta</id>
+      <name>Raman Gupta</name>
+      <email>rgupta@apache.org</email>
+      <url>https://github.com/sponsors/rocketraman</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>America/Toronto</timezone>
+    </developer>
+
+    <developer>
+      <id>tschoening</id>
+      <name>Thorsten Schöning</name>
+      <email>tschoening@apache.org</email>
+      <url>https://github.com/sponsors/ams-tschoening</url>
+      <organization>The Apache Software Foundation</organization>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
   </developers>
 
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <developer>
       <id>pkarwasz</id>
       <name>Piotr P. Karwasz</name>
-      <email>pkarwasz@apache.org</email>
+      <email>pkarwasz-pom@apache.org</email>
       <url>https://github.com/sponsors/ppkarwasz</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -60,7 +60,7 @@
     <developer>
       <id>ckozak</id>
       <name>Carter Kozak</name>
-      <email>ckozak@apache.org</email>
+      <email>ckozak-pom@apache.org</email>
       <url>https://github.com/sponsors/carterkozak</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -72,7 +72,7 @@
     <developer>
       <id>grobmeier</id>
       <name>Christian Grobmeier</name>
-      <email>grobmeier@apache.org</email>
+      <email>grobmeier-pom@apache.org</email>
       <url>https://github.com/sponsors/grobmeier</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -84,7 +84,7 @@
     <developer>
       <id>davydm</id>
       <name>Davyd McColl</name>
-      <email>davydm@apache.org</email>
+      <email>davydm-pom@apache.org</email>
       <url>https://github.com/sponsors/fluffynuts</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -96,7 +96,7 @@
     <developer>
       <id>dpsenner</id>
       <name>Dominik Psenner</name>
-      <email>dpsenner@apache.org</email>
+      <email>dpsenner-pom@apache.org</email>
       <url>https://github.com/sponsors/dpsenner</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -107,7 +107,7 @@
     <developer>
       <id>ggregory</id>
       <name>Gary Gregory</name>
-      <email>ggregory@apache.org</email>
+      <email>ggregory-pom@apache.org</email>
       <url>https://github.com/sponsors/garydgregory</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -119,7 +119,7 @@
     <developer>
       <id>freeandnil</id>
       <name>Jan Friedrich</name>
-      <email>freeandnil@apache.org</email>
+      <email>freeandnil-pom@apache.org</email>
       <url>https://github.com/sponsors/FreeAndNil</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -131,7 +131,7 @@
     <developer>
       <id>mattsicker</id>
       <name>Matt Sicker</name>
-      <email>mattsicker@apache.org</email>
+      <email>mattsicker-pom@apache.org</email>
       <url>https://github.com/sponsors/jvz</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -143,7 +143,7 @@
     <developer>
       <id>rgoers</id>
       <name>Ralph Goers</name>
-      <email>rgoers@apache.org</email>
+      <email>rgoers-pom@apache.org</email>
       <url>https://github.com/sponsors/rgoers</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -155,7 +155,7 @@
     <developer>
       <id>rpopma</id>
       <name>Remko Popma</name>
-      <email>rpopma@apache.org</email>
+      <email>rpopma-pom@apache.org</email>
       <url>https://github.com/sponsors/remkop</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -167,7 +167,7 @@
     <developer>
       <id>rmiddleton</id>
       <name>Robert Middleton</name>
-      <email>rmiddleton@apache.org</email>
+      <email>rmiddleton-pom@apache.org</email>
       <url>https://github.com/sponsors/rm5248</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -178,7 +178,7 @@
     <developer>
       <id>rgrabowski</id>
       <name>Ron Grabowski</name>
-      <email>rgrabowski@apache.org</email>
+      <email>rgrabowski-pom@apache.org</email>
       <url>https://github.com/sponsors/ronosaurus</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -189,7 +189,7 @@
     <developer>
       <id>sdeboy</id>
       <name>Scott Deboy</name>
-      <email>sdeboy@apache.org</email>
+      <email>sdeboy-pom@apache.org</email>
       <url>https://github.com/sponsors/scottdeboy</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -200,7 +200,7 @@
     <developer>
       <id>swebb2066</id>
       <name>Stephen Webb</name>
-      <email>swebb2066@apache.org</email>
+      <email>swebb2066-pom@apache.org</email>
       <url>https://github.com/sponsors/swebb2066</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -212,7 +212,7 @@
     <developer>
       <id>vy</id>
       <name>Volkan Yazıcı</name>
-      <email>vy@apache.org</email>
+      <email>vy-pom@apache.org</email>
       <url>https://github.com/sponsors/vy</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -224,7 +224,7 @@
     <developer>
       <id>jaykatariya</id>
       <name>Jay Katariya</name>
-      <email>jaykatariya@apache.org</email>
+      <email>jaykatariya-pom@apache.org</email>
       <url>https://github.com/sponsors/jaykataria1111</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -236,7 +236,7 @@
     <developer>
       <id>jwthomas</id>
       <name>Jeff Thomas</name>
-      <email>jwthomas@apache.org</email>
+      <email>jwthomas-pom@apache.org</email>
       <url>https://github.com/sponsors/JWT007</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -248,7 +248,7 @@
     <developer>
       <id>rgupta</id>
       <name>Raman Gupta</name>
-      <email>rgupta@apache.org</email>
+      <email>rgupta-pom@apache.org</email>
       <url>https://github.com/sponsors/rocketraman</url>
       <organization>The Apache Software Foundation</organization>
       <roles>
@@ -260,7 +260,7 @@
     <developer>
       <id>tschoening</id>
       <name>Thorsten Schöning</name>
-      <email>tschoening@apache.org</email>
+      <email>tschoening-pom@apache.org</email>
       <url>https://github.com/sponsors/ams-tschoening</url>
       <organization>The Apache Software Foundation</organization>
       <roles>


### PR DESCRIPTION
This change modifies the POM file and adds all the active Apache Logging Services team members as developers in the order:

- PMC Chair
- PMC Member
- Committer

Since jobs come and go and people forget to update the POM file, when they change affiliation, all the entries:

- Use the `@apache.org` e-mail.
- Use `https://github.com/sponsors/<userId>` as URL, which is redirected automatically to `https://github.com/<userId>/` if the user does not have a GitHub Sponsors profile.
- Use `The Apache Software Foundation` as organization.