### PR TITLE
Fix deployment of test artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,9 @@
     <!-- `bnd-maven-plugin` 7.x requires a Maven version `3.8.1` or higher -->
     <minimalMavenBuildVersion>3.8.1</minimalMavenBuildVersion>
 
+    <!-- The same property will be used by `maven-deploy-plugin` and `nexus-staging-maven-plugin` -->
+    <maven.deploy.skip>false</maven.deploy.skip>
+
     <!-- JPMS and OSGi options -->
     <!-- Overrides some options in multi-release JARs -->
     <bnd-multi-release>false</bnd-multi-release>
@@ -1363,6 +1366,7 @@
                 </goals>
                 <configuration>
                   <nexusUrl>https://repository.apache.org</nexusUrl>
+                  <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
                   <serverId>${distMgmtReleasesId}</serverId>
                 </configuration>
               </execution>

--- a/src/changelog/.12.x.x/fix_deployment.xml
+++ b/src/changelog/.12.x.x/fix_deployment.xml
@@ -4,5 +4,6 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="360" link="https://github.com/apache/logging-parent/pull/360"/>
-  <description format="asciidoc">Stop deployment of test artifacts.</description>
+  <description format="asciidoc">Use the `maven.deploy.skip` Maven property in `nexus-staging-maven-plugin`.
+This effectively fixes the skipping of test artifacts' deployments.</description>
 </entry>

--- a/src/changelog/.12.x.x/fix_deployment.xml
+++ b/src/changelog/.12.x.x/fix_deployment.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="360" link="https://github.com/apache/logging-parent/pull/360"/>
+  <description format="asciidoc">Stop deployment of test artifacts.</description>
+</entry>


### PR DESCRIPTION
Due to a difference between plugins used, if the `deploy` profile is activated, artifacts with `maven.deploy.skip` are being **deployed**. This change fixes it.