### PR TITLE
Build website on the fastest runner only

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -154,7 +154,7 @@ jobs:
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache
         # Only build the website on the fastest runner
-        if: inputs.site-enabled && runner.os == 'ubuntu-latest'
+        if: inputs.site-enabled && runner.os == 'Linux'
         id: nodejs-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684   # 4.2.3
         with:
@@ -176,7 +176,7 @@ jobs:
 
       - name: Build the website
         # Only build the website on the fastest runner
-        if: inputs.site-enabled && runner.os == 'ubuntu-latest'
+        if: inputs.site-enabled && runner.os == 'Linux'
         shell: bash
         env:
           # Making Node.js cache hit visible for debugging purposes

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -153,7 +153,8 @@ jobs:
 
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache
-        if: inputs.site-enabled
+        # Only build the website on the fastest runner
+        if: inputs.site-enabled && runner.os == 'ubuntu-latest'
         id: nodejs-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684   # 4.2.3
         with:
@@ -164,7 +165,7 @@ jobs:
           # For that, we need to configure `dependabot` to update hundreds of dependencies listed in `package-lock.json`.
           # That translates to a never ending rain of `dependabot` PRs.
           # I doubt if the wasted CPU cycles worth the gain.
-          key: "${{ runner.os }}-nodejs-cache-${{ hashFiles('node', 'node_modules') }}"
+          key: "nodejs-cache-${{ hashFiles('node', 'node_modules') }}"
           # `actions/cache` doesn't recommend caching `node_modules`.
           # Though none of its recipes fit our bill, since we install Node.js using `frontend-maven-plugin`.
           # See https://github.com/actions/cache/blob/main/examples.md#node---npm
@@ -174,7 +175,8 @@ jobs:
             node_modules
 
       - name: Build the website
-        if: inputs.site-enabled
+        # Only build the website on the fastest runner
+        if: inputs.site-enabled && runner.os == 'ubuntu-latest'
         shell: bash
         env:
           # Making Node.js cache hit visible for debugging purposes

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@feature/disable-site
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@main
     with:
       site-enabled: true
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@main
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@feature/disable-site
     with:
       site-enabled: true
 

--- a/src/changelog/.12.x.x/site_on_single_runner.xml
+++ b/src/changelog/.12.x.x/site_on_single_runner.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <description format="asciidoc">
+    Build website on the fastest runner only in `build-reusable.yaml`.
+  </description>
+</entry>


### PR DESCRIPTION
Site generation logic in `build-reusable.yaml` is currently running on all three runners slowing down builds. When the build is running on a `push` trigger, we can disable site generation entirely, by setting `site-enabled` to `false` and letting `deploy-site-reusable.yaml` do its job. This is no longer possible in PRs, because `deploy-site-reusable.yaml` does not run there.

This PR disables site generation on MacOS and Windows, since we don't expect any differences in the way the website is generated on those platforms.