### PR TITLE
Use workflows on the same branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,14 +44,14 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@main
+    uses: ./.github/workflows/build-reusable.yaml
     with:
       site-enabled: true
 
   deploy-snapshot:
     needs: build
     if: github.repository == 'apache/logging-parent' && github.ref_name == 'main'
-    uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@main
+    uses: ./.github/workflows/deploy-snapshot-reusable.yaml
     # Secrets for deployments
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
@@ -60,7 +60,7 @@ jobs:
   deploy-release:
     needs: build
     if: github.repository == 'apache/logging-parent' && startsWith(github.ref_name, 'release/')
-    uses: apache/logging-parent/.github/workflows/deploy-release-reusable.yaml@main
+    uses: ./.github/workflows/deploy-release-reusable.yaml
     # Secrets for deployments
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -33,7 +33,7 @@ jobs:
 
   deploy-site-stg:
     if: github.repository == 'apache/logging-parent' && github.ref_name == 'main'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@main
+    uses: ./.github/workflows/deploy-site-reusable.yaml
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -50,7 +50,7 @@ jobs:
 
   deploy-site-pro:
     if: github.repository == 'apache/logging-parent' && github.ref_name == 'main-site-pro'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@main
+    uses: ./.github/workflows/deploy-site-reusable.yaml
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -81,7 +81,7 @@ jobs:
 
   deploy-site-rel:
     needs: export-version
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@main
+    uses: ./.github/workflows/deploy-site-reusable.yaml
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}

--- a/.github/workflows/merge-dependabot.yaml
+++ b/.github/workflows/merge-dependabot.yaml
@@ -30,11 +30,11 @@ jobs:
 
   build:
     if: github.repository == 'apache/logging-parent' && github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@main
+    uses: ./.github/workflows/build-reusable.yaml
 
   merge-dependabot:
     needs: build
-    uses: apache/logging-parent/.github/workflows/merge-dependabot-reusable.yaml@main
+    uses: ./.github/workflows/merge-dependabot-reusable.yaml
     permissions:
       contents: write                                             # to push changelog commits
       pull-requests: write                                        # to close the PR


### PR DESCRIPTION
Since most of the PRs to `logging-parent` modify the workflows, we should not run the reusable workflows from the `@main` branch, but from the same branch as the PR.

This PR changes all non-reusable workflows to use the `./.github/workflows/<workflow>` syntax, which uses the workflow file from the same branch as the calling workflow.