### PR TITLE
Replace Maven Cache with Mimír

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -100,7 +100,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -108,14 +109,19 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
           enableCrossOsArchive: true
 

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -89,7 +89,35 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Set up Develocity
         if: inputs.develocity-enabled

--- a/.github/workflows/codeql-analysis-reusable.yaml
+++ b/.github/workflows/codeql-analysis-reusable.yaml
@@ -53,7 +53,35 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Build with Maven
         shell: bash

--- a/.github/workflows/codeql-analysis-reusable.yaml
+++ b/.github/workflows/codeql-analysis-reusable.yaml
@@ -64,7 +64,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -72,16 +73,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       - name: Build with Maven
         shell: bash

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -83,7 +83,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -91,16 +92,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       - name: Set up Git user
         shell: bash

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -68,11 +68,39 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
           server-id: apache.releases.https
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Set up Git user
         shell: bash

--- a/.github/workflows/deploy-site-reusable.yaml
+++ b/.github/workflows/deploy-site-reusable.yaml
@@ -61,8 +61,36 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Build the project
         shell: bash

--- a/.github/workflows/deploy-site-reusable.yaml
+++ b/.github/workflows/deploy-site-reusable.yaml
@@ -73,7 +73,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -81,16 +82,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       - name: Build the project
         shell: bash

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -65,7 +65,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -73,16 +74,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       - name: Export version
         id: version

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -51,10 +51,38 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
           server-id: apache.snapshots.https
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Export version
         id: version

--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -93,7 +93,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -101,16 +102,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       - name: Find the release version major
         shell: bash

--- a/.github/workflows/merge-dependabot-reusable.yaml
+++ b/.github/workflows/merge-dependabot-reusable.yaml
@@ -78,11 +78,39 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
           server-id: apache.releases.https
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       - name: Find the release version major
         shell: bash

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -61,7 +61,35 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
+
+      #
+      # Sets up Mimír (https://maveniverse.eu/docs/mimir/) to cache artifacts from remote repositories
+      #
+      # Unlike the local Maven repository, Mimír cannot be used to stage locally generated artifacts or snapshots.
+      # Therefore, it can be reused between builds, even on different architectures.
+      # Since the size of the cache increases in time, as we download new dependency versions, we reset the cache
+      # once a month.
+      #
+      # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
+      #          copied to multiple workflows.
+      #          All copies should be synchronized with the original: build-reusable.yaml
+      #
+      - name: Set up Mimír configuration
+        shell: bash
+        run: |
+          # Compute the key cache
+          echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
+          # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+
+      - name: Set up Mimír cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        with:
+          # Mimir contains an exact copy of part of Maven Central.
+          # Therefore, we only need to clean it from time to time to remove old versions.
+          key: ${{ env.MIMIR_KEY }}
+          path: .mimir/local
+          enableCrossOsArchive: true
 
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -72,7 +72,8 @@ jobs:
       #
       # WARNING: Currently it is not possible to reuse GitHub workflow steps, therefore, these two steps must be
       #          copied to multiple workflows.
-      #          All copies should be synchronized with the original: build-reusable.yaml
+      #          The `build-reusable` workflow uses `actions/cache`,
+      #          while the other workflows only use `actions/cache/restore`
       #
       - name: Set up Mimír configuration
         shell: bash
@@ -80,16 +81,20 @@ jobs:
           # Compute the key cache
           echo MIMIR_KEY="mimir-cache-$(date +'%Y-%m')" >> $GITHUB_ENV
           # Mimir currently does not support relative paths, so we need to compute the absolute path of `mimir`.
-          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
+          echo MAVEN_OPTS="-Dmimir.daemon.passOnBasedir=true -Dmimir.daemon.autostop=true -Dmimir.basedir=$GITHUB_WORKSPACE/.mimir" >> $GITHUB_ENV
 
       - name: Set up Mimír cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
-          # Mimir contains an exact copy of part of Maven Central.
+          # Mimir is a partial mirror of Maven Central.
           # Therefore, we only need to clean it from time to time to remove old versions.
-          key: ${{ env.MIMIR_KEY }}
+          #
+          # However, GitHub caches are immutable, and we need a unique key to update them.
+          # If no cache hit occurs for this key, we fall back to any other cache.
+          key: "${{ env.MIMIR_KEY }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.MIMIR_KEY }}-
           path: .mimir/local
-          enableCrossOsArchive: true
 
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # Maven
 target/
 .flattened-pom.xml
+/.mimir/
 /.mvn/extensions.xml
 /.mvn/wrapper/maven-wrapper.jar
 # IDEA

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <log4j-changelog-maven-plugin.version>0.9.0</log4j-changelog-maven-plugin.version>
     <maven-artifact-plugin.version>3.6.0</maven-artifact-plugin.version>
+    <mimir.version>0.7.4</mimir.version>
     <restrict-imports-enforcer-rule.version>2.6.1</restrict-imports-enforcer-rule.version>
     <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.44.4</spotless-maven-plugin.version>
@@ -360,6 +361,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-artifact-plugin</artifactId>
           <version>${maven-artifact-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>eu.maveniverse.maven.mimir</groupId>
+          <artifactId>extension</artifactId>
+          <version>${mimir.version}</version>
         </plugin>
 
         <plugin>
@@ -954,6 +961,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <!--
+        ~ Use Mimir as Maven cache:
+        ~ See: https://maveniverse.eu/docs/mimir/
+        -->
+      <plugin>
+        <groupId>eu.maveniverse.maven.mimir</groupId>
+        <artifactId>extension</artifactId>
+        <extensions>true</extensions>
       </plugin>
 
     </plugins>

--- a/src/changelog/.12.x.x/add-mimir.xml
+++ b/src/changelog/.12.x.x/add-mimir.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="389" link="https://github.com/apache/logging-parent/pull/389"/>
+  <description format="asciidoc">Use Mimír instead of Maven local repository cache.</description>
+</entry>


### PR DESCRIPTION
This pull request replaces the use of the Maven local repository cache with [Mimír](https://maveniverse.eu/docs/mimir/), a specialized, immutable cache for remote Maven repositories.

### Description

The Maven local repository serves multiple purposes:

- Mirrors immutable releases from Maven Central
- Caches snapshot artifacts
- Acts as a local staging area for builds

Because of these overlapping responsibilities, the local repository often becomes polluted with temporary artifacts, making it unreliable for consistent, reproducible builds. Additionally, it is not safe to share across workflows.

One major issue caused by sharing the local Maven repository is the occurrence of false negatives in the `verify-reproducibility-reusable` check (see #388).

### Benefits of Using Mimír

Mimír provides a cleaner and more reliable caching approach:

- **Immutable by design**: Only caches artifacts from remote Maven repositories, which do not change.
- **Workflow-friendly**: Enables a single shared cache across workflows without risk of contamination from snapshots or local artifacts.

This change improves build reproducibility, reduces cache-related issues, and simplifies cache management.

Fixes #388