### PR TITLE
Fix staging of binary distribution archive

### DIFF
--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -203,13 +203,8 @@ jobs:
       - name: Stage distribution attachments
         shell: bash
         run: |
-          # Dump deployed artifacts to a local folder
-          export ALT_DEPLOYMENT_REPO_FILEPATH="target/alt-deployment-repo"
-          mkdir "$ALT_DEPLOYMENT_REPO_FILEPATH"
-          ./mvnw \
-            --show-version --batch-mode --errors --no-transfer-progress \
-            -DaltDeploymentRepository=apache.releases.https::file:"$ALT_DEPLOYMENT_REPO_FILEPATH" \
-            deploy:deploy
+          # Folder where the Nexus Staging Maven plugin places the staged artifacts
+          export ALT_DEPLOYMENT_REPO_FILEPATH="target/nexus-staging/staging"
 
           # This regex needs to work for both Java (`distribution` profile) and `find` (while counting attachments)!
           # Hence, we don't escape dots, etc. with backslashes, which is problematic to get working in both worlds.

--- a/src/changelog/.12.x.x/distribution-attachments.xml
+++ b/src/changelog/.12.x.x/distribution-attachments.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="400" link="https://github.com/apache/logging-parent/issues/400"/>
+  <description format="asciidoc">Fix staging of binary distribution archive.</description>
+</entry>


### PR DESCRIPTION
Due to the replacement of Maven Deploy Plugin with Nexus Staging Plugin, the staging process of the binary distribution archive fails.

Since the Nexus Staging Plugin also creates a local staging folder in `target/nexus-staging/staging`, this change simply reuses the already existing folder to retrieve all the published artifacts.