### PR TITLE
Improve reliability of reproducibility verification

### DIFF
--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -61,7 +61,30 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
-          cache: maven
+
+      #
+      # Generates a cache key prefix to enable partial cache hits.
+      # If there's no exact match for the full cache key, any cache with this prefix can be used as a fallback.
+      # To avoid unbounded cache growth, the prefix includes the current month,
+      # ensuring a new cache is started each month.
+      #
+      - name: Compute Cache Key Prefix
+        shell: bash
+        run: |
+          date +"CACHE_KEY=verify-reproducibility-%Y-%m" >> $GITHUB_ENV
+
+      #
+      # Configures caching for the local Maven repository.
+      # Uses a custom cache key to isolate artifacts built in this workflow,
+      # preventing reproducibility results from being affected by cached outputs from other workflows.
+      #
+      - name: Set up Maven Cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684   # 4.2.3
+        with:
+          path: ~/.m2/repository
+          key: "${{ env.CACHE_KEY }}-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}"
+          restore-keys: |
+            ${{ env.CACHE_KEY }}-${{ runner.os }}-
 
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility

--- a/src/changelog/.12.x.x/verify_reproducibility-cache.xml
+++ b/src/changelog/.12.x.x/verify_reproducibility-cache.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="388" link="https://github.com/apache/logging-parent/issues/388"/>
+  <description format="asciidoc">
+    Improve reliability of reproducibility verification.
+  </description>
+</entry>


### PR DESCRIPTION
This change introduces a separate cache specifically for the `verify-reproducibility` workflow to ensure it does not reuse artifacts cached by other workflows. By isolating its cache, we ensure that reproducibility checks are based solely on artifacts built within the same workflow, improving the reliability and accuracy of the verification.

Closes #388