### PR TITLE
Use separate tag for NPM dependency resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,6 @@
     <findsecbugs-plugin.version>1.14.0</findsecbugs-plugin.version>
     <groovy.version>4.0.26</groovy.version>
 
-    <!-- We use a separate property than `project.version` to refer to the most recent _published_ version of the project. -->
-    <stable-project.version>12.1.0</stable-project.version>
-
   </properties>
 
   <dependencyManagement>
@@ -1576,7 +1573,7 @@
                 </goals>
                 <phase>pre-site</phase>
                 <configuration>
-                  <arguments>install github:apache/logging-parent#rel/${stable-project.version}</arguments>
+                  <arguments>install github:apache/logging-parent#site-deps/${revision}</arguments>
                 </configuration>
               </execution>
 

--- a/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
+++ b/src/site/antora/modules/ROOT/pages/release-instructions-project.adoc
@@ -83,6 +83,19 @@ git push -u origin release/7.8.0
 `release/`-prefixed branches trigger a particular GitHub Actions workflow and its run is idempotent.
 You can iterate on the `release/7.8.0` branch to perfect it.
 ====
++
+[NOTE]
+====
+Releasing `logging-parent` requires a workaround due to a circular dependency: the website build should depend on the `rel/7.8.0` tag, but that tag can only be created after the release has been approved.
+
+To break the cycle, the NPM dependencies for building the site use a different tag, `site-deps/7.8.0`, which is hardcoded in `pom.xml`.
+You need to create this tag before staging the release.
+[source,bash]
+----
+git tag -a site-deps/7.8.0 -m 'Site dependencies for 7.8.0 release (RC1)'
+git push origin site-deps/7.8.0
+----
+====
 
 . Verify that the associated {project-github-url}/actions[GitHub Actions workflow] succeeds:
 .. The `project.build.outputTimestamp` property in `pom.xml` is updated
@@ -153,6 +166,16 @@ git push origin rel/7.8.0
 [IMPORTANT]
 ====
 The ASF infrastructure treats ``rel/``-prefixed git tags special and ensures they are immutable for provenance reasons.
+====
++
+[NOTE]
+====
+When releasing `logging-parent`, you also need to move the `site-deps/7.8.0` tag to the `rel/7.8.0` tag.
+[source,bash]
+----
+git tag -a site-deps/7.8.0 rel/7.8.0 -m 'Site dependencies for 7.8.0 release'
+git push -f origin site-deps/7.8.0
+----
 ====
 . Merge the `rel/7.8.0` tag (**not** the `release/7.8.0` branch!) to `main`
 +


### PR DESCRIPTION
In #366, we centralized the process for managing NPM dependencies, replacing the decentralized approach. While this change is transparent for most projects, it introduces a chicken-and-egg problem when releasing `logging-parent`:

* The website build fetches NPM dependency versions from the GitHub repository based on a specific tag, currently `rel/<version_number>`.
* However, for `logging-parent`, the `rel/<version_number>` tag can only be created *after* the release is validated—which requires building the website.

To resolve this, we propose using a mutable tag: `site-deps/<version_number>`. This tag will initially point to the commit preceding the release and allow the website build to proceed. Once the release is finalized and the `rel/<version_number>` tag is available, `site-deps/<version_number>` will be updated to match it.

### Security considerations

I am not a big fan of using mutable tags.
However, previously we had no control on which NPM package versions are used to build the website. Now we lock those dependencies, but we cannot lock the release tag.