### PR TITLE
feat: Restrict permissions in reusable workflows

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -65,6 +65,10 @@ on:
 env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
 
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ concurrency:
   group: ${{ github.ref_name == 'main' && github.ref || github.ref_name }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: { }
 
 jobs:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,8 @@ concurrency:
   group: ${{ github.ref_name == 'main' && github.ref || github.ref_name }}
   cancel-in-progress: true
 
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
 permissions: { }
 
 jobs:

--- a/.github/workflows/codeql-analysis-reusable.yaml
+++ b/.github/workflows/codeql-analysis-reusable.yaml
@@ -31,11 +31,18 @@ on:
         default: java
         type: string
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
 
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # Permissions required to publish Security Alerts
+    permissions:
+      security-events: write
 
     steps:
 

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -27,7 +27,7 @@ on:
   schedule:
     - cron: '32 12 * * 5'
 
-permissions: {}
+permissions: { }
 
 jobs:
 
@@ -36,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     # Permissions required to publish Security Alerts
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     steps:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -27,6 +27,8 @@ on:
   schedule:
     - cron: '32 12 * * 5'
 
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
 permissions: { }
 
 jobs:

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -52,12 +52,20 @@ on:
         description: Subversion password for uploading the release distribution
         required: true
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     outputs:
       project-version: ${{ steps.version.outputs.project-version }}
       nexus-url: ${{ steps.nexus.outputs.nexus-url }}
+    permissions:
+      # Write permissions to allow the Maven `revision` property update, changelog release, etc.
+      contents: write
+
     steps:
 
       - name: Checkout repository

--- a/.github/workflows/deploy-site-reusable.yaml
+++ b/.github/workflows/deploy-site-reusable.yaml
@@ -45,11 +45,17 @@ on:
         description: GPG secret key for signing commits
         required: true
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
 
   deploy:
-
     runs-on: ubuntu-latest
+    permissions:
+      # Write permissions for committing the generated site
+      contents: write
 
     steps:
 

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -27,6 +27,8 @@ on:
       - "**.md"
       - "**.txt"
 
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
 permissions: { }
 
 jobs:

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -27,7 +27,7 @@ on:
       - "**.md"
       - "**.txt"
 
-permissions: read-all
+permissions: { }
 
 jobs:
 

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -60,7 +60,6 @@ jobs:
     with:
       asf-yaml-content: |
         publish:
-          profile: ~
           whoami: ${{ github.ref_name }}-out
           subdir: content/logging-parent
       target-branch: ${{ github.ref_name }}-out

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -36,6 +36,10 @@ on:
         description: Nexus snapshot repository password for deploying artifacts
         required: true
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecards-analysis-reusable.yaml
+++ b/.github/workflows/scorecards-analysis-reusable.yaml
@@ -20,12 +20,18 @@ name: scorecards-analysis
 on:
   workflow_call:
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
 
   analysis:
-
     name: "Scorecards analysis"
     runs-on: ubuntu-latest
+    # Permissions required to publish Security Alerts
+    permissions:
+      security-events: write
 
     steps:
 

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -39,6 +39,10 @@ env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
   NEXUS_URL: ${{ inputs.nexus-url }}
 
+# Explicitly drop all permissions inherited from the caller for security.
+# Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
+permissions: { }
+
 jobs:
 
   build:

--- a/src/changelog/.12.x.x/limit-permissions.xml
+++ b/src/changelog/.12.x.x/limit-permissions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <description format="asciidoc">
+    Restricts permissions in reusable workflows by removing unnecessary permissions inherited from the caller.
+  </description>
+</entry>

--- a/src/site/antora/modules/ROOT/examples/build.yaml
+++ b/src/site/antora/modules/ROOT/examples/build.yaml
@@ -24,7 +24,7 @@ on:
       - "release/2*"
   pull_request:
 
-permissions: read-all
+permissions: { }
 
 jobs:
 

--- a/src/site/antora/modules/ROOT/examples/build.yaml
+++ b/src/site/antora/modules/ROOT/examples/build.yaml
@@ -24,6 +24,8 @@ on:
       - "release/2*"
   pull_request:
 
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
 permissions: { }
 
 jobs:

--- a/src/site/antora/modules/ROOT/examples/deploy-site.yaml
+++ b/src/site/antora/modules/ROOT/examples/deploy-site.yaml
@@ -27,6 +27,8 @@ on:
       - "**.md"
       - "**.txt"
 
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
 permissions: { }
 
 jobs:

--- a/src/site/antora/modules/ROOT/examples/deploy-site.yaml
+++ b/src/site/antora/modules/ROOT/examples/deploy-site.yaml
@@ -27,7 +27,7 @@ on:
       - "**.md"
       - "**.txt"
 
-permissions: read-all
+permissions: { }
 
 jobs:
 
@@ -64,7 +64,6 @@ jobs:
     with:
       asf-yaml-content: |
         publish:
-          profile: ~
           whoami: ${{ github.ref_name }}-out
           subdir: content/log4j/2.x
       install-required: true


### PR DESCRIPTION
This update limits the `GITHUB_TOKEN` permissions granted to reusable workflows, ensuring they operate with only the permissions strictly necessary for their function.

Although GitHub ensures that reusable workflows cannot exceed the permissions granted by the calling workflow, [GitHub documentation](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions) recommends that they explicitly declare the minimal permissions they require. This practice helps prevent misuse in scenarios where a caller might over-provision permissions.

#### 🔐 Updated Permissions by Workflow:

- **`contents: write`** Required only by:
  - `deploy-release-reusable`
  - `deploy-site-reusable` These workflows need write access to push changes to Git branches. For all other workflows, we now explicitly set `contents: none`.

- **`security-events: write`** Required only by:
  - `codeql-analysis-reusable`
  - `scorecards-analysis-reusable` These workflows need this permission to upload security scanning results.

By scoping permissions tightly, we improve our workflows’ security posture without impacting functionality.