### PR TITLE
Test GitHub Rulesets support in `.asf.yaml`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,14 @@
 #
 
 # `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
-# See its documentation for details: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+# See its documentation for details: https://github.com/apache/infrastructure-asfyaml
+
+#
+# Additional non-standard features
+#
+meta:
+  environments:
+    - github_rulesets
 
 # Bare minimum `notifications` to
 #
@@ -61,21 +68,25 @@ github:
   features:
     issues: true
 
-  # Prevent force pushes to primary branches
-  protected_branches:
-    main:
-      # All commits must be signed
-      required_signatures: true
+  # Clear Protected Branches configuration: it is replaced by GitHub Rulesets
+  protected_branches: { }
+
+  rulesets:
+    - name: "Branch protection"
+      type: branch
+      branches:
+        includes:
+          - "test/rulesets"
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
         checks:
-          # The GitHub Actions app: 15368
-          - app_id: 15368
+          # The GitHub Actions app
+          - app_slug: github-actions
             context: "build / build (ubuntu-latest)"
-          # The GitHub Advanced Security app: 57789
-          - app_id: 57789
+          # The GitHub Advanced Security app
+          - app_slug: github-advanced-security
             context: "CodeQL"
       # At least one positive review must be present
       required_pull_request_reviews:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -81,13 +81,12 @@ github:
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
-        checks:
-          # The GitHub Actions app
-          - app_slug: github-actions
-            context: "build / build (ubuntu-latest)"
-          # The GitHub Advanced Security app
-          - app_slug: github-advanced-security
-            context: "CodeQL"
+        # The GitHub Actions app
+        - app_slug: github-actions
+          name: "build / build (ubuntu-latest)"
+        # The GitHub Advanced Security app
+        - app_slug: github-advanced-security
+          name: "CodeQL"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
This change migrates branch protection from the deprecated [Protected Branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) feature to [Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), using the new `rulesets` key added in apache/infrastructure-asfyaml#89.

## Why Rulesets?

- Rules are publicly visible at https://github.com/apache/logging-parent/rules
- The same ruleset can be applied to multiple branches simultaneously
- `app_slug` identifiers replace fragile numeric `app_id` values

The `required_signatures` rule was also dropped, as the project decided commit signing is not useful.

## Testing strategy

The `.asf.yaml` file for Rulesets is only processed from the default branch. This means any mistake on `main` cannot be corrected without direct push access, which itself would be blocked by the broken rule. To avoid that trap, this PR:

1. Applies the new ruleset only to `test/rulesets`, leaving `main` temporarily unprotected
2. This allows direct fixes to `main` if the ruleset turns out to be misconfigured

Once the ruleset is verified to be correct on `test/rulesets`, I will restore full protection to `main` using a direct push.