### PR TITLE
Remove SHA pinning from `actions/*` and `github/*` actions

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -83,13 +83,13 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
 
       - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
@@ -141,7 +141,7 @@ jobs:
       # We upload tests results.
       - name: Upload test reports
         if: ${{ always() && inputs.test-report-enabled }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # 7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: "test-report-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}${{inputs.test-report-suffix}}"
           path: |
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Node.js cache
         if: inputs.site-enabled
         id: nodejs-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae   # 5.0.5
+        uses: actions/cache@v5
         with:
           # We should be calculating the cache key using `package-lock.json` instead!
           # See https://stackoverflow.com/a/48524475/1278899
@@ -204,7 +204,7 @@ jobs:
       # Upload reproducibility results if the build fails.
       - name: Upload reproducibility results
         if: inputs.reproducibility-check-enabled && failure() && steps.reproducibility.conclusion == 'failure'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # 7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: reproducibility-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
           path: |

--- a/.github/workflows/codeql-analysis-reusable.yaml
+++ b/.github/workflows/codeql-analysis-reusable.yaml
@@ -47,16 +47,16 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858    # 3.29.0
+        uses: github/codeql-action/init@v4
         with:
           # Also check GitHub Actions
           languages: ${{ inputs.language }}, actions
 
       - name: Setup JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
@@ -71,4 +71,4 @@ jobs:
           clean verify
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13    # 4.35.1
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-release-reusable.yaml
+++ b/.github/workflows/deploy-release-reusable.yaml
@@ -69,10 +69,10 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up Java & GPG
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
@@ -173,7 +173,7 @@ jobs:
       # Node.js cache is needed for Antora
       - name: Set up Node.js cache
         id: nodejs-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae   # 5.0.5
+        uses: actions/cache@v5
         with:
           # We should be calculating the cache key using `package-lock.json` instead!
           # See https://stackoverflow.com/a/48524475/1278899

--- a/.github/workflows/deploy-site-reusable.yaml
+++ b/.github/workflows/deploy-site-reusable.yaml
@@ -60,10 +60,10 @@ jobs:
     steps:
 
       - name: Checkout the source branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
@@ -82,7 +82,7 @@ jobs:
       # Node.js cache is needed for Antora
       - name: Restore Node.js cache
         id: nodejs-cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae   # 5.0.5
+        uses: actions/cache/restore@v5
         with:
           # The cache is OS independent
           enableCrossOsArchive: true
@@ -112,7 +112,7 @@ jobs:
       # Checking out a new branch will delete the `node_modules` folder,
       # so we need to save the cache here.
       - name: Save Node.js cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae   # 5.0.5
+        uses: actions/cache/save@v5
         with:
           key: ${{ steps.nodejs-cache-restore.outputs.cache-primary-key }}
           path: node_modules
@@ -132,7 +132,7 @@ jobs:
           }
 
       - name: Checkout the target branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target-branch }}
 

--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -48,10 +48,10 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/scorecards-analysis-reusable.yaml
+++ b/.github/workflows/scorecards-analysis-reusable.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -54,13 +54,13 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # 7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13    # 4.35.1
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -56,12 +56,12 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
       - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: ${{ inputs.java-version }}
@@ -83,7 +83,7 @@ jobs:
       # preventing reproducibility results from being affected by cached outputs from other workflows.
       #
       - name: Set up Maven Cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae   # 5.0.5
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: "${{ env.CACHE_KEY }}-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}"
@@ -104,7 +104,7 @@ jobs:
       # Upload reproducibility results if the build fails.
       - name: Upload reproducibility results
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # 7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: reproducibility-${{matrix.os}}-${{github.run_number}}-${{github.run_attempt}}
           path: |


### PR DESCRIPTION
This change replaces SHA-pinned references for actions published by the `actions` and `github` organisations with major version tags (e.g. `actions/checkout@v6`).

It also corrects an inconsistency in `codeql-analysis-reusable.yaml`, where `codeql-action/init` was pinned to a different version than `codeql-action/analyze` and `codeql-action/upload-sarif`.

### Why drop pinning for these organisations?

Pinning to a SHA is the standard defence against supply-chain attacks on GitHub Actions. However, for actions owned by the `actions` and `github` organisations the trade-off looks different:

- **Same trust boundary as the runner.** These organisations own the GitHub Actions infrastructure itself. If either organisation were compromised, the runners that execute workflows would likely be compromised too. Pinning a SHA does not protect against that threat.
- **High churn, low signal.** Every patch release generates a Dependabot PR. Reviewing each one for supply-chain risk requires non-trivial effort, yet in practice every PR gets approved: the review adds no real security value.

Third-party actions (e.g. `gradle/develocity-actions`, `ossf/scorecard-action`) remain SHA-pinned.