### PR TITLE
Run build unconditionally

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,6 @@ permissions: { }
 jobs:
 
   build:
-    if: github.actor != 'dependabot[bot]'
     uses: apache/logging-parent/.github/workflows/build-reusable.yaml@gha/v0
     with:
       site-enabled: true


### PR DESCRIPTION
With `merge-dependabot` out of the way, the `build` workflow should run for all PRs.