### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Develocity Build Scan capture
         if: inputs.develocity-enabled
         # INFRA-approved GHAs: https://github.com/apache/infrastructure-actions/blob/main/actions.yml
-        uses: gradle/develocity-actions/setup-maven@4a2aed82eea165ba2d5c494fc2a8730d7fdff229   # 2.1
+        uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529   # 2.1
         with:
           develocity-access-key: ${{ secrets.DV_ACCESS_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: build
+
+on:
+  pull_request:
+
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    name: build / build (ubuntu-latest)
+
+    steps:
+      - name: Dummy step to fulfill Ruleset
+        shell: bash
+        run: echo Success

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# Perform CodeQL analysis of GitHub Actions
+name: codeql-analysis
+
+on:
+  push:
+    branches:
+    - "gha/v0"
+    - "main"
+  pull_request:
+    branches:
+      - "gha/v0"
+      - "main"
+  schedule:
+    - cron: '32 12 * * 5'
+
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
+
+jobs:
+
+  analyze:
+    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@gha/v0
+    with:
+      language: actions
+    # Permissions required to publish Security Alerts
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -38,11 +38,23 @@ permissions: { }
 jobs:
 
   analyze:
-    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@gha/v0
-    with:
-      language: actions
+    name: Analyze
+    runs-on: ubuntu-latest
     # Permissions required to publish Security Alerts
     permissions:
-      actions: read
-      contents: read
       security-events: write
+
+    # This branch does not have a `pom.xml` file or any Java source code,
+    # therefore we can not reuse the reusable workflow.
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
This commit fixes the CI workflows on this branch so that PRs can be merged:

- Bumps `gradle/develocity-actions` to a version allowed by the ASF (the previous comment was wrong: the version pinned before was 1.4).
- Adds a CodeQL workflow required on this branch.
- Adds a dummy `build / build (ubuntu-latest)` workflow required on this branch.