### PR TITLE
Adds CodeQL workflow to `gha/v0`

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+# Perform CodeQL analysis of GitHub Actions
+name: codeql-analysis
+
+on:
+  push:
+    branches:
+    - "gha/v0"
+  pull_request:
+    branches:
+      - "gha/v0"
+  schedule:
+    - cron: '32 12 * * 5'
+
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
+
+jobs:
+
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    # Permissions required to publish Security Alerts
+    permissions:
+      security-events: write
+
+    # This branch does not have a `pom.xml` file or any Java source code,
+    # therefore we can not reuse the reusable workflow.
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
This workflow is a simplified version of `codeql-analysis-reusable`, since this branch has no Java project and the reusable workflow would fail to find a `pom.xml` file necessary to compute the cache key.