### PR TITLE
Switch to GitHub Rulesets (second attempt)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,13 +18,6 @@
 # `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
 # See its documentation for details: https://github.com/apache/infrastructure-asfyaml
 
-#
-# Additional non-standard features
-#
-meta:
-  environments:
-    - github_rulesets
-
 # Bare minimum `notifications` to
 #
 # 1. Forward GitHub _activity_ to `notifications@`
@@ -105,8 +98,21 @@ github:
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1
+    # Use raw rules, until a convenience notation for `restrict_update` is introduced.
+    # See: https://github.com/apache/infrastructure-asfyaml/issues/96
+    #
+    # The raw rules need to follow the syntax given in:
+    # https://docs.github.com/en/rest/repos/rules?apiVersion=2026-03-10#update-a-repository-ruleset
     - name: "Tag protection"
-      type: tag
-      branches:
-        includes:
-          - "rel/*"
+      target: tag
+      enforcement: active
+      bypass_actors: []
+      conditions:
+        ref_name:
+          include:
+            - "refs/tags/rel/*"
+          exclude: []
+      rules:
+        - type: deletion
+        - type: non_fast_forward
+        - type: update

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,13 @@
 # `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
 # See its documentation for details: https://github.com/apache/infrastructure-asfyaml
 
+#
+# Additional non-standard features
+#
+meta:
+  environments:
+    - github_rulesets
+
 # Bare minimum `notifications` to
 #
 # 1. Forward GitHub _activity_ to `notifications@`
@@ -61,32 +68,45 @@ github:
   features:
     issues: true
 
-  # Prevent force pushes to primary branches
-  protected_branches:
-    main:
+  # Clear Protected Branches configuration: it is replaced by GitHub Rulesets
+  protected_branches: ~
+
+  rulesets:
+    - name: "Branch protection: parent POM"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
-        checks:
-          # The GitHub Actions app: 15368
-          - app_id: 15368
-            context: "build / build (ubuntu-latest)"
-          # The GitHub Advanced Security app: 57789
-          - app_id: 57789
-            context: "CodeQL"
+        # The GitHub Actions app
+        - app_slug: github-actions
+          name: "build / build (ubuntu-latest)"
+        # The GitHub Advanced Security app
+        - app_slug: github-advanced-security
+          name: "CodeQL"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1
-    gha/v0:
+    - name: "Branch protection: reusable actions"
+      type: branch
+      branches:
+        includes:
+          - "gha/*"
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
-        checks:
-          # The GitHub Advanced Security app: 57789
-          - app_id: 57789
-            context: "CodeQL"
+        # The GitHub Advanced Security app
+        - app_slug: github-advanced-security
+          name: "CodeQL"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1
+    - name: "Tag protection"
+      type: tag
+      branches:
+        includes:
+          - "rel/*"


### PR DESCRIPTION
The first attempt (#456) had to be reverted in #471 because a bug in ASFYaml made the resulting rulesets impossible to modify or remove through `.asf.yaml`. We rolled back to the legacy `protected_branches` configuration.

apache/infrastructure-asfyaml#93 has now landed and addresses the underlying issues (broken `app_slug` resolution, silent REST API failures, missing `refs/heads/` / `refs/tags/` prefixing), so we can move back to Rulesets.

The benefits over `protected_branches` remain:

- Tag references can also be protected (see the new `rel/*` ruleset).
- A single ruleset can target a glob of refs (e.g. `gha/*`) instead of one branch at a time.
- Rules are publicly visible at https://github.com/apache/logging-parent/rules, so we can verify that the effective rules are those configured and third parties can audit the project's protection policy too.