### PR TITLE
Simplify the `<developers>` section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,20 @@
       </roles>
     </developer>
 
+    <!-- Don't remove these entries -->
+    <developer>
+      <id>ggregory</id>
+      <name>Gary Gregory</name>
+      <email>ggregory@apache.org</email>
+      <url>https://www.garygregory.com</url>
+      <organization>The Apache Software Foundation</organization>
+      <organizationUrl>https://www.apache.org/</organizationUrl>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>America/New_York</timezone>
+    </developer>
+
   </developers>
 
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,7 @@
 
   <inceptionYear>1999</inceptionYear>
 
-  <!--
-    These entries exist only to satisfy the Maven Central requirement of at least one
-    developer with a name and an email address. They deliberately point to stable team
-    aliases instead of individuals.
-
-    The `<developers>` section is inherited by child projects, so these entries apply to
-    the whole Apache Logging Services family and should NOT be overridden downstream.
-
-    We do not track individual developers or contributors here: Git history and the
-    project team page (https://logging.apache.org/team-list.html) are the authoritative,
-    always up-to-date sources.
-    -->
+  <!-- Maven Central requires a `developers` element containing at least one `developer` to with a `name` and an `email`. -->
   <developers>
 
     <developer>
@@ -79,20 +68,6 @@
       <roles>
         <role>security</role>
       </roles>
-    </developer>
-
-    <!-- Don't remove these entries -->
-    <developer>
-      <id>ggregory</id>
-      <name>Gary Gregory</name>
-      <email>ggregory@apache.org</email>
-      <url>https://www.garygregory.com</url>
-      <organization>The Apache Software Foundation</organization>
-      <organizationUrl>https://www.apache.org/</organizationUrl>
-      <roles>
-        <role>PMC Member</role>
-      </roles>
-      <timezone>America/New_York</timezone>
     </developer>
 
   </developers>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,19 @@
       </roles>
     </developer>
 
+    <developer>
+      <id>ggregory</id>
+      <name>Gary Gregory</name>
+      <email>ggregory@apache.org</email>
+      <url>https://www.garygregory.com</url>
+      <organization>The Apache Software Foundation</organization>
+      <organizationUrl>https://www.apache.org/</organizationUrl>
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>America/New_York</timezone>
+    </developer>
+
   </developers>
 
   <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -43,60 +43,42 @@
 
   <inceptionYear>1999</inceptionYear>
 
+  <!--
+    These entries exist only to satisfy the Maven Central requirement of at least one
+    developer with a name and an email address. They deliberately point to stable team
+    aliases instead of individuals.
+
+    The `<developers>` section is inherited by child projects, so these entries apply to
+    the whole Apache Logging Services family and should NOT be overridden downstream.
+
+    We do not track individual developers or contributors here: Git history and the
+    project team page (https://logging.apache.org/team-list.html) are the authoritative,
+    always up-to-date sources.
+    -->
   <developers>
 
     <developer>
-      <id>ggregory</id>
-      <name>Gary Gregory</name>
-      <email>ggregory@apache.org</email>
-      <url>https://www.garygregory.com</url>
+      <id>logging-dev</id>
+      <name>Apache Logging Services Project Management Committee (PMC)</name>
+      <email>dev@logging.apache.org</email>
+      <url>https://logging.apache.org/team-list.html</url>
       <organization>The Apache Software Foundation</organization>
       <organizationUrl>https://www.apache.org/</organizationUrl>
       <roles>
-        <role>PMC Member</role>
+        <role>PMC</role>
       </roles>
-      <timezone>America/New_York</timezone>
     </developer>
 
     <developer>
-      <id>grobmeier</id>
-      <name>Christian Grobmeier</name>
-      <email>grobmeier@apache.org</email>
+      <id>logging-security</id>
+      <name>Apache Logging Services Security Team</name>
+      <email>security@logging.apache.org</email>
+      <url>https://logging.apache.org/security.html</url>
+      <organization>The Apache Software Foundation</organization>
+      <organizationUrl>https://www.apache.org/</organizationUrl>
       <roles>
-        <role>PMC Member</role>
+        <role>security</role>
       </roles>
-      <timezone>Europe/Berlin</timezone>
-    </developer>
-
-    <developer>
-      <id>mattsicker</id>
-      <name>Matt Sicker</name>
-      <email>mattsicker@apache.org</email>
-      <organization>Apple</organization>
-      <roles>
-        <role>PMC Member</role>
-      </roles>
-      <timezone>America/Chicago</timezone>
-    </developer>
-
-    <developer>
-      <id>pkarwasz</id>
-      <name>Piotr P. Karwasz</name>
-      <email>pkarwasz@apache.org</email>
-      <roles>
-        <role>PMC Member</role>
-      </roles>
-      <timezone>Europe/Warsaw</timezone>
-    </developer>
-
-    <developer>
-      <id>vy</id>
-      <name>Volkan Yazıcı</name>
-      <email>vy@apache.org</email>
-      <roles>
-        <role>PMC Chair</role>
-      </roles>
-      <timezone>Europe/Amsterdam</timezone>
     </developer>
 
   </developers>


### PR DESCRIPTION
### What

Replace the fixed list of five named PMC members in `<developers>` with two stable, role-based team entries:

- **Apache Logging Services PMC** (`dev@logging.apache.org`) for general development matters
- **Apache Logging Services Security Team** (`security@logging.apache.org`) as the security contact

Both carry the ASF `<organization>`, a team/security page URL, and a free-form `<role>`.

### Why

The previous list had the problems any hand-maintained contributor roster has:

- **It is always incomplete.** A fixed list inevitably omits contributors, and the choice of who appears is arbitrary. Git history (and, for the ASF, the [project team page](https://logging.apache.org/team-list.html) and `projects.apache.org`) already track this accurately and automatically.
- **Contact details go stale.** People change employers, time zones, and email addresses, and eventually stop working on the project. A POM published inside a release is immutable, so any individual detail is a future inaccuracy.
- **Listing individuals implies a support obligation.** People named in the POM are not necessarily willing or able to answer questions about the project. Stable team aliases route questions to whoever is currently active.

The `<developers>` section is **not** free to delete, though: Maven Central requires at least one developer with a `name` and `email` (see the [Central requirements](https://central.sonatype.org/publish/requirements/)). The two meta-entries satisfy that requirement while pointing at durable, monitored channels instead of individuals.

### Who actually consumes this data?

Very little tooling reads `<developers>` programmatically, which is itself an argument against maintaining a detailed list. The consumers that do matter are served better by this change:

- **Maven Central publishing validation** requires the section to be non-empty. Satisfied.
- **`maven-project-info-reports-plugin`** generates `team-list.html` from this section, but we do **not** use Maven Site Plugin.
- **SBOM tooling (CycloneDX / SPDX)** maps `<developers>` to SBOM authors and `<organization>` to manufacturer/supplier, so adding `<organization>` improves provenance metadata.

### Inheritance / downstream impact

`<developers>` is inherited by child projects. These entries therefore apply to the whole Apache Logging Services family, and child POMs **should not override them**. A comment in the POM documents this intent.
