### PR TITLE
Disable Maven Site plugin globally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,10 @@
     <!-- The same property will be used by `maven-deploy-plugin` and `nexus-staging-maven-plugin` -->
     <maven.deploy.skip>false</maven.deploy.skip>
 
+    <!-- Disable `maven-site-plugin` globally: sites are generated with Antora (see the `antora` profile) -->
+    <maven.site.skip>true</maven.site.skip>
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
+
     <!-- JPMS and OSGi options -->
     <!-- Overrides some options in multi-release JARs -->
     <bnd-multi-release>false</bnd-multi-release>
@@ -1426,14 +1430,6 @@
           <exists>src/site/antora</exists>
         </file>
       </activation>
-
-      <properties>
-
-        <!-- disable `maven-site-plugin`-->
-        <maven.site.skip>true</maven.site.skip>
-        <maven.site.deploy.skip>true</maven.site.deploy.skip>
-
-      </properties>
 
       <build>
         <plugins>

--- a/src/changelog/.12.x.x/disable-maven-site-plugin.xml
+++ b/src/changelog/.12.x.x/disable-maven-site-plugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <description format="asciidoc">
+    Disable Maven Site plugin globally, instead of only in modules containing `src/site/antora`.
+  </description>
+</entry>


### PR DESCRIPTION
The `antora` profile covered two separate concerns:

1. Site generation with Antora, correctly activated by the presence of `src/site/antora`. This stays as is.
2. Disabling Maven Site plugin via `maven.site.skip` and `maven.site.deploy.skip`.

Since no project uses Maven Site plugin any more, the skip properties are moved to the global `<properties>` section. Previously, sub-modules in a multi-module repo had to disable Maven Site Plugin on their own.