### PR TITLE
Fix duplicate `exec-maven-plugin.version` from a bad merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
     <bnd-baseline-maven-plugin.version>7.2.3</bnd-baseline-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
-    <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
     <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
     <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>


### PR DESCRIPTION
Commit 873899ead0b997140568a1d5e1d227d2efa7135b ("Add options to enable Develocity") accidentally re-added an `exec-maven-plugin.version` declaration next to the existing one, most likely due to a badly resolved merge or rebase. Since then Dependabot has been bumping both declarations independently (they currently read `3.4.1` and `3.6.3`).
