### PR TITLE
Replace "draft trick" documentation with auto-merge flow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,13 +26,6 @@ on:
       - "**.md"
       - "**.txt"
   pull_request:
-    types:
-      # Standard types
-      - opened
-      - synchronize
-      - reopened
-      # Used in Dependabot PRs to retrigger required workflows
-      - ready_for_review
 
 # If the branch is `main`, run once per commit.
 # If the branch is `release/*`, allow only one concurrent run.

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -26,13 +26,6 @@ on:
   pull_request:
     branches:
       - "main"
-    types:
-      # Standard types
-      - opened
-      - synchronize
-      - reopened
-      # Used in Dependabot PRs to retrigger required workflows
-      - ready_for_review
   schedule:
     - cron: '32 12 * * 5'
 

--- a/.github/workflows/process-dependabot.yaml
+++ b/.github/workflows/process-dependabot.yaml
@@ -39,9 +39,9 @@ jobs:
       }}
     uses: apache/logging-parent/.github/workflows/process-dependabot-reusable.yaml@gha/v0
     permissions:
-      # The default GITHUB_TOKEN will be used to enable the "auto-merge" on the PR
-      # This requires the following two permissions:
+      # Append the changelog commit
       contents: write
+      # Enable auto-merge on the PR
       pull-requests: write
     with:
       # The path to the changelog directory for the current development branch.

--- a/src/site/antora/modules/ROOT/examples/process-dependabot.yaml
+++ b/src/site/antora/modules/ROOT/examples/process-dependabot.yaml
@@ -40,7 +40,7 @@ jobs:
     permissions:
       # Append the changelog commit
       contents: write
-      # Convert the PR into draft
+      # Enable auto-merge on the PR
       pull-requests: write
     with:
       # The path to the changelog directory for the current development branch.

--- a/src/site/antora/modules/ROOT/pages/workflows.adoc
+++ b/src/site/antora/modules/ROOT/pages/workflows.adoc
@@ -127,7 +127,7 @@ include::example$analyze-dependabot.yaml[tag=analyze-dependabot,indent=0]
 Helps to process Dependabot pull requests by:
 
 * Generating changelog entries for the updated dependencies and committing them to the PR branch.
-* Switching the pull request into “draft mode”.
+* Enabling the “auto-merge” option on the pull request.
 
 The workflow only needs the default `GITHUB_TOKEN` with `contents: write` and `pull-requests: write` permissions.
 
@@ -135,31 +135,16 @@ This workflow is designed to be triggered by the `workflow_run` event, as soon a
 
 [NOTE]
 ====
-Pushes made with `GITHUB_TOKEN` do not retrigger workflows (GitHub anti-recursion rule), so the changelog commit cannot re-run the required checks on its own.
-This reusable workflow therefore parks the PR in “draft mode” and stops there.
+Pushes made with `GITHUB_TOKEN` do not automatically retrigger workflows (GitHub anti-recursion rule), so the changelog commit cannot re-run the required checks on its own.
+However,
+https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/[since June 2026],
+the workflow runs are created in an approval-required state instead of being dropped, and a maintainer can start them manually.
 
 The expected flow for each Dependabot PR is:
 
-. The reusable workflow appends the changelog commit and converts the PR into draft.
-. A maintainer reviews the change, clicks *Ready for review*, and enables *Auto-merge*.
-. The required-check workflows re-run against the new HEAD; once they pass, *Auto-merge* completes the merge without further manual action.
-
-For step 3 to work, every workflow providing a required check must subscribe to `ready_for_review`:
-
-[source,yaml]
-----
-on:
-  pull_request:
-    types:
-      # Standard types
-      - opened
-      - synchronize
-      - reopened
-      # Used in Dependabot PRs to retrigger required workflows
-      - ready_for_review
-----
-
-This reusable workflow does **not** enable “Auto-merge”; a maintainer must do that by hand.
+. The reusable workflow appends the changelog commit to the PR branch and enables “auto-merge”.
+. A maintainer reviews the change, approves the PR, and clicks *Approve workflows to run*.
+. The required-check workflows run against the new HEAD; once they pass, *Auto-merge* completes the merge without further manual action.
 ====
 
 .Snippet from an {examples-base-link}/process-dependabot.yaml[example `process-dependabot.yaml`] using this workflow


### PR DESCRIPTION
Follow-up to #500, which replaces the draft-mode step in `process-dependabot-reusable.yaml` with enabling auto-merge.

Since GitHub's June 11, 2026 change [Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/), workflow runs triggered by the changelog commit pushed with `GITHUB_TOKEN` are created in an **approval-required state** instead of being silently dropped. A maintainer can start the required checks with the "Approve workflows to run" button, so the "draft trick" introduced in #475 and documented in #476 is no longer necessary, and the reusable workflow enables auto-merge on the PR again.

Changes:

- Update the `process-dependabot-reusable.yaml` documentation in `workflows.adoc` to describe the new flow: the workflow appends the changelog commit and enables auto-merge; a maintainer approves the PR and clicks "Approve workflows to run"; the PR merges automatically once the required checks pass.
- Remove the `ready_for_review` trigger from `build.yaml` and `codeql-analysis.yaml`, restoring their pre-#476 state with the default `pull_request` types.
