### PR TITLE
Align Apache RAT configuration with the ATR license check

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,2 @@
+.java-version
+src/changelog/**/*.xml

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,8 @@
     <restrict-imports-enforcer-rule.version>3.0.0</restrict-imports-enforcer-rule.version>
     <spotbugs-maven-plugin.version>4.9.8.3</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+    <!-- RAT `0.18` requires Java 17; therefore `org.apache:apache` is stuck on RAT `0.16.1` -->
+    <version.apache-rat-plugin>0.18</version.apache-rat-plugin>
     <xml-maven-plugin.version>1.2.1</xml-maven-plugin.version>
 
     <!-- plugin dependencies versions -->
@@ -587,21 +589,31 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
+        <!-- Mirror the RAT invocation of the ASF Trusted Releases platform (ATR):
+             https://github.com/apache/tooling-trusted-releases/blob/main/atr/tasks/checks/rat.py -->
         <configuration>
           <consoleOutput>true</consoleOutput>
+          <inputExcludeStds>
+            <inputExcludeStd>MISC</inputExcludeStd>
+            <inputExcludeStd>HIDDEN_DIR</inputExcludeStd>
+            <inputExcludeStd>MAC</inputExcludeStd>
+          </inputExcludeStds>
+          <counterMins>
+            <counterMin>LICENSE_CATEGORIES:0</counterMin>
+            <counterMin>LICENSE_NAMES:0</counterMin>
+            <counterMin>STANDARDS:0</counterMin>
+          </counterMins>
           <excludes combine.children="append">
-            <exclude>.java-version</exclude>
-            <exclude>.mvn/jvm.config</exclude>
-            <exclude>**/*.txt</exclude>
-            <!-- The license header in changelog entry files causing Git to match irrelevant files.
-                 This is eventually causing merge conflicts.
-                 Hence, we avoid enforcing license headers there. -->
-            <exclude>src/changelog/**/*.xml</exclude>
-            <!-- License headers in GitHub templates pollute the prompt displayed to the user: -->
-            <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
-            <exclude>.github/pull_request_template.md</exclude>
-            <!-- `.logging-parent-bom-activator` activates the `bom` Maven profile: -->
-            <exclude>.logging-parent-bom-activator</exclude>
+            <!-- Generated files, always excluded by ATR (`GENERATED_FILE_SUFFIXES` in `atr/constants.py`): -->
+            <exclude>**/*.bundle.js</exclude>
+            <exclude>**/*.chunk.js</exclude>
+            <exclude>**/*.css.map</exclude>
+            <exclude>**/*.js.map</exclude>
+            <exclude>**/*.min.css</exclude>
+            <exclude>**/*.min.js</exclude>
+            <exclude>**/*.min.map</exclude>
+            <!-- ATR excludes the `.rat-excludes` file itself from the check: -->
+            <exclude>.rat-excludes</exclude>
           </excludes>
         </configuration>
         <executions>
@@ -933,6 +945,72 @@
   </build>
 
   <profiles>
+
+    <!-- The two `apache-rat-*` profiles below mirror the behavior of the ATR license check:
+         - when the checked tree contains no `.rat-excludes` file,
+           ATR applies the SCM and IDE related standard exclusion collections;
+         - when a `.rat-excludes` file is present, ATR passes it via the `input-exclude-file` option instead.
+
+         The `.rat-excludes` file is looked up in the root directory of the multi-module build,
+         which corresponds to the root of the source archive checked by ATR.
+         See: https://github.com/apache/tooling-trusted-releases/blob/main/atr/tasks/checks/rat.py -->
+    <profile>
+
+      <id>apache-rat-std-excludes</id>
+
+      <activation>
+        <file>
+          <missing>${maven.multiModuleProjectDirectory}/.rat-excludes</missing>
+        </file>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+              <inputExcludeStds combine.children="append">
+                <inputExcludeStd>MAVEN</inputExcludeStd>
+                <inputExcludeStd>ECLIPSE</inputExcludeStd>
+                <inputExcludeStd>IDEA</inputExcludeStd>
+                <inputExcludeStd>GIT</inputExcludeStd>
+                <inputExcludeStd>STANDARD_SCMS</inputExcludeStd>
+              </inputExcludeStds>
+            </configuration>
+          </plugin>
+
+        </plugins>
+      </build>
+
+    </profile>
+
+    <profile>
+
+      <id>apache-rat-excludes-file</id>
+
+      <activation>
+        <file>
+          <exists>${maven.multiModuleProjectDirectory}/.rat-excludes</exists>
+        </file>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+              <inputExcludeFile>${maven.multiModuleProjectDirectory}/.rat-excludes</inputExcludeFile>
+            </configuration>
+          </plugin>
+
+        </plugins>
+      </build>
+
+    </profile>
 
     <!-- `bom` profile to generate BOMs -->
     <profile>

--- a/src/changelog/.12.x.x/align-rat-with-atr.xml
+++ b/src/changelog/.12.x.x/align-rat-with-atr.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <description format="asciidoc">
+      Update Apache RAT to `0.18` and align its configuration with the license check of the ASF Trusted Releases platform (ATR).
+      Project-specific exclusions must now be placed in a `.rat-excludes` file in the root directory of the build.
+  </description>
+</entry>


### PR DESCRIPTION
## Motivation

During a release, the [ASF Trusted Releases platform (ATR)](https://github.com/apache/tooling-trusted-releases) re-checks the source archive with the Apache RAT CLI (see [`atr/tasks/checks/rat.py`](https://github.com/apache/tooling-trusted-releases/blob/main/atr/tasks/checks/rat.py)). ATR never reads the Maven POM: the only exclusion mechanisms it honors are its own predefined exclusions and a `.rat-excludes` file found in the archive. Any exclusion that lives only in the POM therefore hides a failure locally that ATR will later report against the release candidate.

This PR makes the local `apache-rat-plugin` check behave like the ATR check, so a build passing `verify` also passes ATR.

## Changes

- Update `apache-rat-plugin` from `0.16.1` (managed by `org.apache:apache`) to `0.18`.
- The POM configuration now contains only what ATR itself always applies:
  - the `MISC`, `HIDDEN_DIR` and `MAC` standard exclusion collections,
  - the generated-file patterns (`*.min.js`, `*.css.map`, etc. from `GENERATED_FILE_SUFFIXES` in `atr/constants.py`),
  - the `LICENSE_CATEGORIES:0`, `LICENSE_NAMES:0` and `STANDARDS:0` counter minimums.
- Two file-activated profiles reproduce ATR's two code paths, keyed on `${maven.multiModuleProjectDirectory}/.rat-excludes`:
  - `apache-rat-std-excludes` (file absent): additionally applies the `MAVEN`, `ECLIPSE`, `IDEA`, `GIT` and `STANDARD_SCMS` collections, as ATR does for archives without a `.rat-excludes` file;
  - `apache-rat-excludes-file` (file present): passes the file to RAT via `inputExcludeFile`, and the SCM/IDE collections are not applied, as in ATR.
- All project-specific exclusions need to be removed from the POM and moved to a new `.rat-excludes` file.

## Impact on downstream projects

Projects inheriting from `logging-parent` no longer inherit POM-level RAT excludes beyond the ATR-predefined ones. Each project must provide its own `.rat-excludes` at its repository root. This is intentional: those exclusions were invisible to ATR anyway, and the file makes them effective both locally and during the ATR release check.
