### PR TITLE
Pass a native Windows path in MAVEN_BASEDIR to Maven builds

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -60,6 +60,9 @@ on:
 
 env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
+  # Keep `maven.multiModuleProjectDirectory` a native Windows path under `shell: bash`,
+  # See https://github.com/apache/maven/issues/12537 for context.
+  MAVEN_BASEDIR: ${{ github.workspace }}
 
 # Explicitly drop all permissions inherited from the caller for security.
 # Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -38,6 +38,9 @@ on:
 env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
   NEXUS_URL: ${{ inputs.nexus-url }}
+  # Keep `maven.multiModuleProjectDirectory` a native Windows path under `shell: bash`,
+  # See https://github.com/apache/maven/issues/12537 for context.
+  MAVEN_BASEDIR: ${{ github.workspace }}
 
 # Explicitly drop all permissions inherited from the caller for security.
 # Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions


### PR DESCRIPTION
Sets `MAVEN_BASEDIR` to `${{ github.workspace }}` in `build-reusable.yaml`, so that Maven receives `maven.multiModuleProjectDirectory` as a native Windows path.

## Motivation

The build runs `./mvnw` under `shell: bash` on all platforms. On Windows runners this means Git Bash (MinGW). Using Maven 3 with this shell, we end up with a mixed Windows path (`D:/foo/bar/baz`), which triggers issue [RAT-559](https://issues.apache.org/jira/browse/RAT-559)).

The workaround overrides that default value with a Windows path in **canonical** form.

The workaround can be removed when either RAT-559 or its workaround apache/maven#12537 (backport of the MinGW path conversion to the 3.x line) are published.
