### PR TITLE
Pin reproducibility checks to the deployed snapshot

### DIFF
--- a/.github/workflows/deploy-snapshot-reusable.yaml
+++ b/.github/workflows/deploy-snapshot-reusable.yaml
@@ -28,6 +28,9 @@ on:
       project-version:
         description: The version of the project
         value: ${{ jobs.deploy.outputs.project-version }}
+      repository-artifact-name:
+        description: Name of the run artifact containing the deployed Maven repository
+        value: ${{ jobs.deploy.outputs.repository-artifact-name }}
     secrets:
       NEXUS_USERNAME:
         description: Nexus snapshot repository username for deploying artifacts
@@ -45,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       project-version: ${{ steps.version.outputs.project-version }}
+      repository-artifact-name: deploy-snapshot-repository
     steps:
 
       - name: Checkout repository
@@ -83,3 +87,13 @@ jobs:
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -P deploy
+
+      # `nexus-staging-maven-plugin` gathers the artifacts in this directory before uploading them.
+      # `verify-reproducibility-reusable` uses this artifact.
+      - name: Upload deployed repository
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-snapshot-repository
+          path: target/nexus-staging/deferred
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -28,7 +28,14 @@ on:
         description: Additional Maven arguments
         type: string
       nexus-url:
-        description: The URL of the reference Nexus repository
+        description: >
+          The URL of the reference Nexus repository.
+          Exactly one of `nexus-url` and `reference-artifact-name` must be provided.
+        type: string
+      reference-artifact-name:
+        description: >
+          Name of a run artifact containing the reference Maven repository.
+          Exactly one of `nexus-url` and `reference-artifact-name` must be provided.
         type: string
       runs-on:
         description: The type of runners to use as JSON array
@@ -37,7 +44,6 @@ on:
 
 env:
   MAVEN_ARGS: ${{ inputs.maven-args }}
-  NEXUS_URL: ${{ inputs.nexus-url }}
 
 # Explicitly drop all permissions inherited from the caller for security.
 # Reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#access-and-permissions
@@ -90,15 +96,44 @@ jobs:
           restore-keys: |
             ${{ env.CACHE_KEY }}-${{ runner.os }}-
 
+      # Contains the exact artifacts deployed by `deploy-snapshot-reusable`.
+      - name: Download reference repository
+        if: inputs.reference-artifact-name
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.reference-artifact-name }}
+          path: ${{ runner.temp }}/reference-repository
+
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Verify build reproducibility
         shell: bash
+        env:
+          NEXUS_URL: ${{ inputs.nexus-url }}
+          REFERENCE_ARTIFACT_NAME: ${{ inputs.reference-artifact-name }}
         run: |
+          REFERENCE_REPO="$NEXUS_URL"
+
+          # Computes the URI of the local repository, if `reference-artifact-name` was given.
+          if [ -n "$REFERENCE_ARTIFACT_NAME" ]; then
+            TEMP_DIR="$RUNNER_TEMP"
+            # On Windows, convert `D:\a\_temp` to `D:/a/_temp`
+            if command -v cygpath > /dev/null; then
+              TEMP_DIR=$(cygpath -m "$TEMP_DIR")
+            fi
+            # Strip the leading `/`, if present, to form a valid `file:///` URL on all platforms
+            REFERENCE_REPO="file:///${TEMP_DIR#/}/reference-repository"
+          fi
+
+          # Runs Maven
+          if [ -z "$REFERENCE_REPO" ]; then
+            echo '::error::Either `nexus-url` or `reference-artifact-name` must be provided.'
+            exit 1
+          fi
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -DskipTests=true \
-            -Dreference.repo="${NEXUS_URL}" \
+            -Dreference.repo="${REFERENCE_REPO}" \
             clean verify artifact:compare
 
       # Upload reproducibility results if the build fails.

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -112,7 +112,12 @@ jobs:
           NEXUS_URL: ${{ inputs.nexus-url }}
           REFERENCE_ARTIFACT_NAME: ${{ inputs.reference-artifact-name }}
         run: |
-          REFERENCE_REPO="$NEXUS_URL"
+          REFERENCE_REPO=""
+
+          if [ -n "$NEXUS_URL" ] && [ -n "$REFERENCE_ARTIFACT_NAME" ]; then
+            echo '::error::Provide exactly one of `nexus-url` or `reference-artifact-name`, not both.'
+            exit 1
+          fi
 
           # Computes the URI of the local repository, if `reference-artifact-name` was given.
           if [ -n "$REFERENCE_ARTIFACT_NAME" ]; then
@@ -123,10 +128,9 @@ jobs:
             fi
             # Strip the leading `/`, if present, to form a valid `file:///` URL on all platforms
             REFERENCE_REPO="file:///${TEMP_DIR#/}/reference-repository"
-          fi
-
-          # Runs Maven
-          if [ -z "$REFERENCE_REPO" ]; then
+          elif [ -n "$NEXUS_URL" ]; then
+            REFERENCE_REPO="$NEXUS_URL"
+          else
             echo '::error::Either `nexus-url` or `reference-artifact-name` must be provided.'
             exit 1
           fi


### PR DESCRIPTION
Currently `verify-reproducibility-reusable.yaml` resolves the reference artifacts from the Nexus snapshot repository, so a snapshot deployed by a concurrent run can be picked up instead of the one produced by the current run.

This PR fixes the race condition, by uploading the snapshot repo as a workflow artifact:

- `deploy-snapshot-reusable.yaml` now publishes the local staging directory of `nexus-staging-maven-plugin` (`target/nexus-staging/deferred`, the exact bits uploaded to Nexus) as a run artifact and exports its name as a `repository-artifact-name` output.
- `verify-reproducibility-reusable.yaml` accepts a new `reference-artifact-name` input. When set, the artifact is downloaded and used as a `file://` reference repository. Exactly one of `nexus-url` and `reference-artifact-name` must be provided.

The release path is unaffected: releases are verified against their dedicated staging repository via `nexus-url`, which is already immutable per release.
