### PR TITLE
Purge snapshots from the Maven cache in reproducibility checks

### DIFF
--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -141,8 +141,8 @@ jobs:
           # Snapshot artifacts restored from the GitHub Actions cache shadow the reference repository during resolution,
           # so their presence means the cache was polluted by a previous run.
           if [ -d ~/.m2/repository ]; then
-            find ~/.m2/repository -type d -name '*-SNAPSHOT' -prune | while IFS= read -r dir; do
-              find "$dir" -type f | while IFS= read -r file; do
+            find ~/.m2/repository -type d -name '*-SNAPSHOT' -prune -print0 | while IFS= read -r -d '' dir; do
+              find "$dir" -type f -print0 | while IFS= read -r -d '' file; do
                 echo "::warning::Purging stale snapshot file: $file"
               done
               rm -rf "$dir"

--- a/.github/workflows/verify-reproducibility-reusable.yaml
+++ b/.github/workflows/verify-reproducibility-reusable.yaml
@@ -112,13 +112,13 @@ jobs:
           NEXUS_URL: ${{ inputs.nexus-url }}
           REFERENCE_ARTIFACT_NAME: ${{ inputs.reference-artifact-name }}
         run: |
-          REFERENCE_REPO=""
-
           if [ -n "$NEXUS_URL" ] && [ -n "$REFERENCE_ARTIFACT_NAME" ]; then
             echo '::error::Provide exactly one of `nexus-url` or `reference-artifact-name`, not both.'
             exit 1
           fi
 
+          echo '::group::Determine reference repository'
+          REFERENCE_REPO=""
           # Computes the URI of the local repository, if `reference-artifact-name` was given.
           if [ -n "$REFERENCE_ARTIFACT_NAME" ]; then
             TEMP_DIR="$RUNNER_TEMP"
@@ -134,11 +134,37 @@ jobs:
             echo '::error::Either `nexus-url` or `reference-artifact-name` must be provided.'
             exit 1
           fi
+          echo "Using reference repository: $REFERENCE_REPO"
+          echo '::endgroup::'
+
+          echo '::group::Purge snapshots from the local Maven repository'
+          # Snapshot artifacts restored from the GitHub Actions cache shadow the reference repository during resolution,
+          # so their presence means the cache was polluted by a previous run.
+          if [ -d ~/.m2/repository ]; then
+            find ~/.m2/repository -type d -name '*-SNAPSHOT' -prune | while IFS= read -r dir; do
+              find "$dir" -type f | while IFS= read -r file; do
+                echo "::warning::Purging stale snapshot file: $file"
+              done
+              rm -rf "$dir"
+            done
+          fi
+          echo '::endgroup::'
+
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -DskipTests=true \
             -Dreference.repo="${REFERENCE_REPO}" \
             clean verify artifact:compare
+
+      # Remove all snapshots from the local Maven repository before it is saved to the GitHub Actions cache,
+      # so that the reference artifacts resolved by `artifact:compare` do not contaminate the cache.
+      - name: Purge snapshots from Maven cache
+        if: always()
+        shell: bash
+        run: |
+          if [ -d ~/.m2/repository ]; then
+            find ~/.m2/repository -type d -name '*-SNAPSHOT' -prune -exec rm -rf {} +
+          fi
 
       # Upload reproducibility results if the build fails.
       - name: Upload reproducibility results


### PR DESCRIPTION
Fixes `verify-reproducibility-reusable` comparing builds against stale artifacts instead of the declared reference repository.

The `artifact:compare` goal resolves reference artifacts through the Maven resolver, which stores them in the local repository under their regular coordinates. Since the workflow caches `~/.m2/repository`, the next run finds the snapshot already present and never fetches it from the reference repository again.

Changes to `verify-reproducibility-reusable`:

* Log the reference repository URI in a dedicated log group.
* Before the build, purge all `*-SNAPSHOT` directories from the local Maven repository, emitting a `::warning::` for each file found, since their presence indicates a polluted cache.
* After the build, silently purge all `*-SNAPSHOT` directories again (with `if: always()`), so the cache saved by the post step stays clean.
